### PR TITLE
🔧 build: update Claude Code plugin configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,6 @@
     }
   },
   "enabledPlugins": {
-    "example-skills@anthropic-agent-skills": [],
-    "document-skills@anthropic-agent-skills": []
+    "example-skills@anthropic-agent-skills": true
   }
 }


### PR DESCRIPTION
## Summary
Updates the Claude Code plugin configuration to enable only the example-skills plugin.

## Changes
- Enabled example-skills plugin (changed from empty array to true)
- Removed document-skills plugin from configuration
- Standardized plugin enablement format

## Test Plan
- [x] Configuration file is valid JSON
- [x] Follows project's .claude/settings.json structure

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)