### PR TITLE
🔧 build: configure GH_PROJECT_PAT for GitHub Actions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,7 @@
     "ANTHROPIC_SMALL_FAST_MODEL": "${{ secrets.ANTHROPIC_SMALL_FAST_MODEL }}",
     "AWS_REGION": "${{ secrets.AWS_REGION }}",
     "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
-    "CLAUDE_CODE_USE_BEDROCK": "1"
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+    "GH_PROJECT_PAT": "${{ secrets.GH_PROJECT_PAT }}"
   }
 }


### PR DESCRIPTION
## Summary
Fixes the "Unexpected end of JSON input" error that occurs when Claude Code loads skills in GitHub Actions.

## Problem
The `update-github-issue-project-status` skill requires the `GITHUB_PROJECT_PAT` (or `GH_PROJECT_PAT`) environment variable. This was not configured for GitHub Actions, causing Claude Code to fail during skill initialization.

Error from workflow run:
```
A setting named GITHUB_PROJECT_PAT was found, but it could not be loaded correctly. 
Please check the environment file or your local settings file. 
Error: Unexpected end of JSON input
```

## Changes
- Added `GH_PROJECT_PAT` to `.claude/settings.json` env section
- Configured to read from GitHub Actions secret: `${{ secrets.GH_PROJECT_PAT }}`
- Added the secret value to repository secrets (already completed)

Note: Used `GH_PROJECT_PAT` instead of `GITHUB_PROJECT_PAT` because GitHub Actions restricts secret names starting with `GITHUB_`.

## Related Issues
- Fixes error in https://github.com/codekiln/langstar/actions/runs/18821298265/job/53697223932
- Related to work on #17

## Test Plan
- [x] Added `GH_PROJECT_PAT` to GitHub Actions secrets
- [x] Updated `.claude/settings.json` to reference the secret
- [ ] Verify next Claude Code workflow run succeeds

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)