### PR TITLE
🔧 build: remove env section from .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,14 +9,5 @@
   },
   "enabledPlugins": {
     "example-skills@anthropic-agent-skills": true
-  },
-  "env": {
-    "ANTHROPIC_BEDROCK_BASE_URL": "${{ secrets.ANTHROPIC_BEDROCK_BASE_URL }}",
-    "ANTHROPIC_MODEL": "${{ secrets.ANTHROPIC_MODEL }}",
-    "ANTHROPIC_SMALL_FAST_MODEL": "${{ secrets.ANTHROPIC_SMALL_FAST_MODEL }}",
-    "AWS_REGION": "${{ secrets.AWS_REGION }}",
-    "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
-    "CLAUDE_CODE_USE_BEDROCK": "1",
-    "GH_PROJECT_PAT": "${{ secrets.GH_PROJECT_PAT }}"
   }
 }


### PR DESCRIPTION
## Summary
Removes the `env` section from `.claude/settings.json` that was overriding local environment variables with GitHub Actions placeholder values.

## Problem
The `env` section contained placeholder values like `${{ secrets.GH_PROJECT_PAT }}` that are meant for GitHub Actions. When running locally in the devcontainer, these placeholders were overriding the actual environment variables set in `.devcontainer/.env`, causing authentication failures.

## Changes
- Removed the entire `env` section from `.claude/settings.json`
- Environment variables are now properly sourced from:
  - `.devcontainer/.env` (local development, gitignored)
  - GitHub Actions secrets (CI/CD)

## Test Plan
- [x] Verified that local environment variables from `.devcontainer/.env` are no longer overridden
- [x] Confirmed that scripts requiring `GH_PROJECT_PAT` now work correctly
- [x] Settings file is valid JSON

## Related Issues
Fixes #26

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)