### PR TITLE
✨ feat: Phase 4 - Default-to-Private Behavior for Scoped Operations

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -34,4 +34,4 @@ pub use auth::AuthConfig;
 pub use client::{LangchainClient, ListResponse};
 pub use error::{LangstarError, Result};
 pub use organization::{Organization, Workspace};
-pub use prompts::{CommitRequest, CommitResponse, Prompt, PromptClient};
+pub use prompts::{CommitRequest, CommitResponse, Prompt, PromptClient, Visibility};

--- a/sdk/tests/integration_test.rs
+++ b/sdk/tests/integration_test.rs
@@ -128,7 +128,7 @@ async fn test_list_prompts_from_prompthub() {
     println!("Fetching prompts from PromptHub...");
 
     // List prompts (limit to 5 for faster test)
-    let result = client.prompts().list(Some(5), None).await;
+    let result = client.prompts().list(Some(5), None, None).await;
 
     match result {
         Ok(prompts) => {


### PR DESCRIPTION
## Summary

Implements Phase 4 (Default-to-Private Behavior) for organization/workspace scoping. When operations are scoped to an organization or workspace, they now default to showing only private prompts unless the `--public` flag is specified.

## Changes

### SDK Layer (`sdk/src/prompts.rs`)

**New Visibility Enum:**
```rust
pub enum Visibility {
    Public,   // Only public prompts
    Private,  // Only private prompts
    Any,      // All prompts (no filter)
}
```

**Updated Methods:**
- `list()` - Added `visibility` parameter with client-side filtering
- `search()` - Added `visibility` parameter with client-side filtering
- Exported `Visibility` from `sdk/src/lib.rs`

**Filtering Logic:**
- `Visibility::Public` → Filter where `is_public == true`
- `Visibility::Private` → Filter where `is_public == false`
- `Visibility::Any` → No filtering (returns all prompts)

### CLI Layer (`cli/src/commands/prompt.rs`)

**Added `--public` Flag:**
- Added to `prompt list` command
- Added to `prompt search` command

**New Helper Method:**
```rust
fn determine_visibility(client: &LangchainClient, public_flag: bool) -> Visibility
```

**Default Behavior Logic:**
1. **Scoped (org/workspace ID set) + no `--public` flag** → `Visibility::Private`
2. **Scoped + `--public` flag** → `Visibility::Public`
3. **Not scoped** → `Visibility::Any` (current behavior)

### Test Updates
- Fixed `sdk/tests/integration_test.rs` to use new `list()` signature

## Behavior Examples

### Without Scoping (No org/workspace ID)
```bash
# Shows all prompts (public + private) - unchanged behavior
langstar prompt list
```

### With Scoping (org/workspace ID set)
```bash
# Set scoping via environment variable
export LANGSMITH_ORGANIZATION_ID="org-123"

# Defaults to private prompts only (NEW!)
langstar prompt list

# Explicitly show only public prompts
langstar prompt list --public

# Search also respects visibility
langstar prompt search "query"           # Private prompts
langstar prompt search "query" --public  # Public prompts
```

### Via CLI Flags
```bash
# Scoping via flags, defaults to private
langstar prompt list --organization-id "org-123"

# Override to public
langstar prompt list --organization-id "org-123" --public
```

## Related Issues

- Sub-task of #46 (Parent feature)
- Depends on #66 (Phase 1: Research & Experimentation) - **Merged**
- Depends on #67 (Phase 2: SDK Layer) - **Merged**
- Depends on #68 (Phase 3: CLI Layer) - **Merged**
- Fixes #69

## Testing

✅ **All pre-commit checks passed:**
- `cargo fmt` - Code formatted
- `cargo check --workspace` - Compilation successful
- `cargo clippy --workspace` - No linting warnings
- `cargo test --workspace` - 19 tests passed (6 CLI + 13 SDK)
- `cargo fmt --check` - Formatting verified

## Breaking Changes

**SDK API Changes:**
- `PromptClient::list()` signature changed:
  - Old: `list(limit: Option<u32>, offset: Option<u32>)`
  - New: `list(limit: Option<u32>, offset: Option<u32>, visibility: Option<Visibility>)`
  
- `PromptClient::search()` signature changed:
  - Old: `search(query: &str, limit: Option<u32>)`
  - New: `search(query: &str, limit: Option<u32>, visibility: Option<Visibility>)`

**Migration:**
```rust
// Old
client.prompts().list(Some(10), None).await?;

// New (pass None to get same behavior)
client.prompts().list(Some(10), None, None).await?;

// Or explicitly specify
use langstar_sdk::Visibility;
client.prompts().list(Some(10), None, Some(Visibility::Any)).await?;
```

## Next Steps

After this PR merges:
- Phase 5: Testing (comprehensive integration tests)
- Phase 6: Documentation (user guides, examples)
- Phase 7: Error Handling & UX Polish

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>