### PR TITLE
🔧 debug: enable full Claude output to debug errors

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,6 +47,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: "true"
+          show_full_output: true
           claude_args: |
             --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
             --max-turns 10


### PR DESCRIPTION
## Purpose

Enable  in the Claude workflow to see what error Claude is encountering during execution.

## Current Issue

The workflow runs successfully for ~3 minutes and authenticates to Bedrock, but Claude reports an error. The actual error message is hidden by default for security.

## Changes

- Added  to 

## Next Steps

After merging, test again on issue #48 to see the full error output and debug the actual issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)