### PR TITLE
✨ feat(sdk): Phase 1 - Multi-SDK Architecture Setup

### DIFF
--- a/sdk/src/assistants.rs
+++ b/sdk/src/assistants.rs
@@ -1,0 +1,245 @@
+use crate::client::LangchainClient;
+use crate::error::Result;
+use serde::{Deserialize, Serialize};
+
+/// A LangGraph assistant (configured instance of a graph)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Assistant {
+    /// Unique identifier for the assistant
+    pub assistant_id: String,
+    /// Graph ID this assistant is based on
+    pub graph_id: String,
+    /// Name of the assistant
+    pub name: String,
+    /// Configuration for the assistant
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
+    /// Metadata for the assistant
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    /// When the assistant was created
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// When the assistant was last updated
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+/// Request to create a new assistant
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateAssistantRequest {
+    /// Graph ID to base the assistant on
+    pub graph_id: String,
+    /// Name for the assistant
+    pub name: String,
+    /// Optional configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
+    /// Optional metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request to update an existing assistant
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateAssistantRequest {
+    /// Updated name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Updated configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
+    /// Updated metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request to search for assistants
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantSearchRequest {
+    /// Search query (searches assistant names)
+    pub query: String,
+    /// Maximum number of results (default: 20)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Number of results to skip (default: 0)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+}
+
+/// Client for interacting with LangGraph Assistants API
+pub struct AssistantClient<'a> {
+    client: &'a LangchainClient,
+}
+
+impl<'a> AssistantClient<'a> {
+    /// Create a new AssistantClient
+    pub fn new(client: &'a LangchainClient) -> Self {
+        Self { client }
+    }
+
+    /// List all assistants
+    ///
+    /// # Arguments
+    /// * `limit` - Maximum number of assistants to return (default: 20)
+    /// * `offset` - Number of assistants to skip (default: 0)
+    pub async fn list(&self, limit: Option<u32>, offset: Option<u32>) -> Result<Vec<Assistant>> {
+        let limit = limit.unwrap_or(20);
+        let offset = offset.unwrap_or(0);
+
+        let path = format!("/assistants?limit={}&offset={}", limit, offset);
+        let request = self.client.langgraph_get(&path)?;
+
+        // LangGraph API returns a paginated response with an "assistants" field
+        #[derive(Deserialize)]
+        struct ListAssistantsResponse {
+            assistants: Vec<Assistant>,
+        }
+
+        let response: ListAssistantsResponse = self.client.execute(request).await?;
+        Ok(response.assistants)
+    }
+
+    /// Search for assistants by name
+    ///
+    /// # Arguments
+    /// * `query` - Search query string
+    /// * `limit` - Maximum number of results (default: 20)
+    pub async fn search(&self, query: &str, limit: Option<u32>) -> Result<Vec<Assistant>> {
+        let request_body = AssistantSearchRequest {
+            query: query.to_string(),
+            limit,
+            offset: None,
+        };
+
+        let path = "/assistants/search";
+        let request = self.client.langgraph_post(path)?.json(&request_body);
+
+        // LangGraph API returns a list of assistants
+        #[derive(Deserialize)]
+        struct SearchAssistantsResponse {
+            assistants: Vec<Assistant>,
+        }
+
+        let response: SearchAssistantsResponse = self.client.execute(request).await?;
+        Ok(response.assistants)
+    }
+
+    /// Get a specific assistant by ID
+    ///
+    /// # Arguments
+    /// * `assistant_id` - The assistant ID
+    pub async fn get(&self, assistant_id: &str) -> Result<Assistant> {
+        let path = format!("/assistants/{}", assistant_id);
+        let request = self.client.langgraph_get(&path)?;
+
+        let assistant: Assistant = self.client.execute(request).await?;
+        Ok(assistant)
+    }
+
+    /// Create a new assistant
+    ///
+    /// # Arguments
+    /// * `request` - The create assistant request
+    pub async fn create(&self, request: &CreateAssistantRequest) -> Result<Assistant> {
+        let path = "/assistants";
+        let req = self.client.langgraph_post(path)?.json(request);
+
+        let assistant: Assistant = self.client.execute(req).await?;
+        Ok(assistant)
+    }
+
+    /// Update an existing assistant
+    ///
+    /// # Arguments
+    /// * `assistant_id` - The assistant ID to update
+    /// * `request` - The update assistant request
+    pub async fn update(
+        &self,
+        assistant_id: &str,
+        request: &UpdateAssistantRequest,
+    ) -> Result<Assistant> {
+        let path = format!("/assistants/{}", assistant_id);
+        let req = self.client.langgraph_patch(&path)?.json(request);
+
+        let assistant: Assistant = self.client.execute(req).await?;
+        Ok(assistant)
+    }
+
+    /// Delete an assistant
+    ///
+    /// # Arguments
+    /// * `assistant_id` - The assistant ID to delete
+    pub async fn delete(&self, assistant_id: &str) -> Result<()> {
+        let path = format!("/assistants/{}", assistant_id);
+        let request = self.client.langgraph_delete(&path)?;
+
+        // DELETE typically returns 204 No Content, so we need to handle empty response
+        let response = request.send().await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(crate::error::LangstarError::ApiError {
+                status: status.as_u16(),
+                message: error_text,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+impl LangchainClient {
+    /// Get an AssistantClient for interacting with assistants
+    pub fn assistants(&self) -> AssistantClient<'_> {
+        AssistantClient::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::AuthConfig;
+
+    #[test]
+    fn test_assistant_client_creation() {
+        let auth = AuthConfig::new(None, Some("test".to_string()), None, None);
+        let client = LangchainClient::new(auth).unwrap();
+        let _assistant_client = client.assistants();
+    }
+
+    #[test]
+    fn test_assistant_serialization() {
+        let assistant = Assistant {
+            assistant_id: "test-id".to_string(),
+            graph_id: "graph-123".to_string(),
+            name: "Test Assistant".to_string(),
+            config: Some(serde_json::json!({"key": "value"})),
+            metadata: None,
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            updated_at: Some("2024-01-01T00:00:00Z".to_string()),
+        };
+
+        let json = serde_json::to_string(&assistant).unwrap();
+        assert!(json.contains("test-id"));
+        assert!(json.contains("Test Assistant"));
+    }
+
+    #[test]
+    fn test_create_request_serialization() {
+        let request = CreateAssistantRequest {
+            graph_id: "graph-123".to_string(),
+            name: "My Assistant".to_string(),
+            config: Some(serde_json::json!({"temperature": 0.7})),
+            metadata: None,
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("graph-123"));
+        assert!(json.contains("My Assistant"));
+    }
+}

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -190,6 +190,42 @@ impl LangchainClient {
             .header("Content-Type", "application/json"))
     }
 
+    /// Create a POST request to LangGraph API
+    pub fn langgraph_post(&self, path: &str) -> Result<RequestBuilder> {
+        let api_key = self.auth.require_langgraph_key()?;
+        let url = format!("{}{}", self.langgraph_base_url, path);
+
+        Ok(self
+            .http_client
+            .post(&url)
+            .header("x-api-key", api_key)
+            .header("Content-Type", "application/json"))
+    }
+
+    /// Create a PATCH request to LangGraph API
+    pub fn langgraph_patch(&self, path: &str) -> Result<RequestBuilder> {
+        let api_key = self.auth.require_langgraph_key()?;
+        let url = format!("{}{}", self.langgraph_base_url, path);
+
+        Ok(self
+            .http_client
+            .patch(&url)
+            .header("x-api-key", api_key)
+            .header("Content-Type", "application/json"))
+    }
+
+    /// Create a DELETE request to LangGraph API
+    pub fn langgraph_delete(&self, path: &str) -> Result<RequestBuilder> {
+        let api_key = self.auth.require_langgraph_key()?;
+        let url = format!("{}{}", self.langgraph_base_url, path);
+
+        Ok(self
+            .http_client
+            .delete(&url)
+            .header("x-api-key", api_key)
+            .header("Content-Type", "application/json"))
+    }
+
     /// Execute a request and parse the response
     pub async fn execute<T: for<'de> Deserialize<'de>>(
         &self,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -23,6 +23,7 @@
 //! }
 //! ```
 
+pub mod assistants;
 pub mod auth;
 pub mod client;
 pub mod error;
@@ -30,6 +31,10 @@ pub mod organization;
 pub mod prompts;
 
 // Re-export commonly used types
+pub use assistants::{
+    Assistant, AssistantClient, AssistantSearchRequest, CreateAssistantRequest,
+    UpdateAssistantRequest,
+};
 pub use auth::AuthConfig;
 pub use client::{LangchainClient, ListResponse};
 pub use error::{LangstarError, Result};


### PR DESCRIPTION
## Summary

Implements **Phase 1: Multi-SDK Architecture Setup** for Epic #83 - restructures SDK to support multiple OpenAPI specifications (LangSmith + LangGraph).

This phase establishes the foundation for LangGraph assistants support by extending the HTTP client and creating the assistants module with full CRUD operations.

## Changes

### Extended LangchainClient with LangGraph HTTP methods
- `langgraph_post()` - Create POST requests to LangGraph API  
- `langgraph_patch()` - Create PATCH requests to LangGraph API
- `langgraph_delete()` - Create DELETE requests to LangGraph API
- All methods follow the same pattern as existing `langgraph_get()`

### Created Assistants Module (`sdk/src/assistants.rs`)
- **Data Models**:
  - `Assistant` - LangGraph assistant resource
  - `CreateAssistantRequest` - Create assistant request
  - `UpdateAssistantRequest` - Update assistant request
  - `AssistantSearchRequest` - Search request with query filtering

- **AssistantClient** with full CRUD operations:
  - `list()` - List all assistants with pagination
  - `search()` - Search assistants by name ⭐ (critical feature)
  - `get()` - Get assistant by ID
  - `create()` - Create new assistant
  - `update()` - Update existing assistant
  - `delete()` - Delete assistant

### Updated SDK Exports (`sdk/src/lib.rs`)
- Added `assistants` module
- Re-exported assistant types for ergonomic access

## Architecture

The `AssistantClient` follows the same pattern as `PromptClient` for consistency:
- Lifetime-bound reference to `LangchainClient`
- Async methods returning `Result<T>`
- Uses new LangGraph HTTP methods
- Proper error handling with structured responses

## Test Results

✅ **All 55 tests passed**
- 15 unit tests (CLI)
- 13 integration tests (CLI scoping)
- 16 unit tests (SDK)
- 8 integration tests (SDK org/workspace scoping)
- 3 doc tests

## Related Issues

Fixes #90 (Phase 1 of Epic #83)
Part of #83

## Next Steps

Phase 2 will implement the CLI commands for assistants, building on this foundation.

## Test Plan

- [x] All workspace tests pass (`cargo test --workspace --all-features`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy --workspace --all-features`)
- [x] Compilation successful (`cargo check --workspace --all-features`)
- [x] New SDK types have unit tests
- [x] Assistant client creation tests pass

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)