### PR TITLE
✨ feat(cli): Add deployment auto-discovery for assistant commands

### DIFF
--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -77,6 +77,28 @@ impl LangchainClient {
         self.workspace_id.as_deref()
     }
 
+    /// Override the LangGraph base URL for deployment-specific operations
+    ///
+    /// This method allows you to set a custom LangGraph deployment URL
+    /// instead of using the default `https://api.langgraph.cloud`.
+    /// This is useful when targeting a specific LangGraph deployment
+    /// that has a custom URL (e.g., from Control Plane API's `custom_url` field).
+    ///
+    /// # Arguments
+    /// * `url` - The custom deployment URL (e.g., "https://my-deployment.us.langgraph.app")
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use langstar_sdk::{LangchainClient, AuthConfig};
+    /// # let auth = AuthConfig::new(None, Some("key".into()), None, None);
+    /// let client = LangchainClient::new(auth).unwrap()
+    ///     .with_langgraph_url("https://my-deployment.us.langgraph.app".to_string());
+    /// ```
+    pub fn with_langgraph_url(mut self, url: String) -> Self {
+        self.langgraph_base_url = url;
+        self
+    }
+
     /// Create a new client with custom base URLs (useful for testing)
     pub fn with_base_urls(
         auth: AuthConfig,


### PR DESCRIPTION
Fixes #103

## Summary

Implements a **simplified auto-discovery approach** using the Control Plane API instead of manual deployment registration.

This PR enables assistant commands to target specific LangGraph deployments by auto-discovering them via the Control Plane API.

## Problem

Assistant commands had no way to specify which LangGraph deployment to target. Users with multiple deployments couldn't switch between them.

## Solution

**Auto-discovery via Control Plane API:**
1. Users discover deployments: `langstar graph list`
2. Users specify deployment: `langstar assistant list --deployment <name-or-id>`
3. CLI queries Control Plane API to find deployment
4. Extract `custom_url` from `deployment.source_config`
5. Apply URL to client for assistant operations

**No config storage. No new commands. Simple and always up-to-date.**

---

## Changes

### SDK Changes (`sdk/`)

**`sdk/src/deployments.rs`:**
- Added `Deployment::custom_url()` method (lines 112-138)
  - Extracts `custom_url` from `source_config` JSON
  - Returns `Option<String>`
- Added unit test `test_deployment_custom_url_extraction`
  - Tests with URL present
  - Tests without source_config
  - Tests with source_config but no URL

**`sdk/src/client.rs`:**
- Added `LangchainClient::with_langgraph_url()` method (lines 80-100)
  - Overrides default LangGraph base URL
  - Chainable builder pattern
  - Enables deployment-specific operations

### CLI Changes (`cli/`)

**`cli/src/commands/assistant.rs`:**
- Added `--deployment` flag to all 6 commands (required)
  - `List`, `Search`, `Get`, `Create`, `Update`, `Delete`
  - Accepts deployment name OR ID
  - Help text: "Deployment name or ID (from 'langstar graph list')"

- Added `resolve_deployment_url()` helper (lines 154-198)
  - Queries Control Plane API (limit 100 deployments)
  - Finds deployment by matching name or ID
  - Extracts `custom_url` from deployment
  - Clear error messages:
    - "Deployment 'X' not found. Run 'langstar graph list' to see available deployments."
    - "Deployment 'X' has no custom_url in source_config"

- Updated `execute()` method (lines 200-424)
  - Resolves deployment at start of execution
  - Applies `.with_langgraph_url()` to client
  - All 6 command handlers updated

### Documentation

**`README.md`:**
- Added comprehensive "LangGraph Deployments and Assistants" section (lines 112-311)
- Prerequisites and configuration
- Discovering deployments with `langstar graph list`
- Managing assistants (all 6 commands with examples)
- How deployment resolution works
- Error handling examples
- Complete end-to-end workflow example

---

## Usage Examples

### Discover Deployments

```bash
$ langstar graph list
Name                ID                Status  Created
my-prod-deployment  abc-123e4567...   READY   2024-01-15
my-staging          def-456e4567...   READY   2024-01-20
```

### Use Deployment by Name

```bash
$ langstar assistant list --deployment my-prod-deployment
```

### Use Deployment by ID

```bash
$ langstar assistant list --deployment abc-123e4567
```

### Error Handling

```bash
$ langstar assistant list --deployment nonexistent
Error: Deployment 'nonexistent' not found. Run 'langstar graph list' to see available deployments.
```

---

## Technical Details

### Deployment Resolution Flow

```rust
// 1. Extract deployment name from command
let deployment_name = match self {
    AssistantCommands::List { deployment, .. } => deployment,
    // ...
};

// 2. Query Control Plane API
let deployments_list = client.deployments().list(Some(100), Some(0), None).await?;

// 3. Find by name or ID
let deployment = deployments_list.resources.iter()
    .find(|d| d.name == deployment_name_or_id || d.id == deployment_name_or_id)
    .ok_or(...)?;

// 4. Extract custom_url
let url = deployment.custom_url().ok_or(...)?;

// 5. Apply to client
let client = LangchainClient::new(auth)?.with_langgraph_url(url);
```

### API Response Structure

The Control Plane API returns deployments with this structure:

```json
{
  "name": "my-deployment",
  "source_config": {
    "custom_url": "https://my-deployment.us.langgraph.app",
    "integration_id": "...",
    "deployment_type": "dev"
  }
}
```

The `Deployment::custom_url()` method extracts the nested `custom_url` field.

---

## Testing

### Pre-commit Checks ✅

```bash
# All passing
✅ cargo fmt
✅ cargo check --workspace --all-features
✅ cargo clippy --workspace --all-features -- -D warnings
✅ cargo test --workspace --lib
```

### Unit Tests (22 passing)

New test added:
- `test_deployment_custom_url_extraction` (sdk/src/deployments.rs)
  - Tests URL extraction with custom_url present
  - Tests without source_config (returns None)
  - Tests with source_config but no custom_url (returns None)

All existing tests still passing:
- SDK: 22 tests (auth, client, deployments, prompts, assistants, organization)
- CLI: 17 tests (config, output, commands)

### Integration Tests

Integration tests require `LANGCHAIN_WORKSPACE_ID` environment variable and are expected to fail without credentials. This is by design and will be addressed in Phase 5 (#94).

---

## Benefits of Auto-Discovery

✅ **No config storage** - Nothing to maintain  
✅ **Always up-to-date** - Fetches live deployment list  
✅ **No new commands** - Reuses `langstar graph list`  
✅ **Simpler** - ~50% less code than manual registration  
✅ **Better UX** - Explicit discovery workflow  
✅ **Clear errors** - Actionable error messages guide users

---

## Breaking Changes

None - this adds new functionality without changing existing behavior.

The `--deployment` flag is required for assistant commands, but assistant commands are new in Phase 3 and haven't been released yet.

---

## Related Issues

- Sub-task of #92 (Phase 3: CLI Commands Implementation)
- Part of Epic #83 (LangGraph Deployment Assistants Support v0.2.0)

---

## Next Steps

After this PR is merged into `claude/92-cli-commands-implementation`:
1. Merge PR #102 (if separate) or continue with Phase 3 work
2. Complete Phase 3 by merging `claude/92-cli-commands-implementation` into `release/v0.2.0`
3. Proceed to Phase 4 (#93 - Test LangGraph Deployment Setup)
4. Then Phase 5 (#94 - Integration Testing)

---

## Files Changed

- `sdk/src/deployments.rs` - 26 lines added (impl + test)
- `sdk/src/client.rs` - 21 lines added (method + docs)
- `cli/src/commands/assistant.rs` - 78 lines added/modified
- `README.md` - 200 lines added (comprehensive docs)

**Total:** ~325 lines (code + tests + docs)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>