### PR TITLE
🩹 fix(sdk): assistant search endpoint returns direct array

### DIFF
--- a/sdk/src/assistants.rs
+++ b/sdk/src/assistants.rs
@@ -115,14 +115,10 @@ impl<'a> AssistantClient<'a> {
         let path = "/assistants/search";
         let request = self.client.langgraph_post(path)?.json(&request_body);
 
-        // LangGraph API returns a list of assistants
-        #[derive(Deserialize)]
-        struct SearchAssistantsResponse {
-            assistants: Vec<Assistant>,
-        }
-
-        let response: SearchAssistantsResponse = self.client.execute(request).await?;
-        Ok(response.assistants)
+        // LangGraph API search endpoint returns a direct array of assistants
+        // (unlike list endpoint which returns {assistants: [...]})
+        let response: Vec<Assistant> = self.client.execute(request).await?;
+        Ok(response)
     }
 
     /// Get a specific assistant by ID


### PR DESCRIPTION
## Summary

Fixes the SDK's `AssistantClient::search()` method to correctly handle the LangGraph API's response format. The `/assistants/search` endpoint returns a direct array of assistants, unlike the `/assistants` list endpoint which returns a wrapped object.

## Problem

The SDK was expecting:
```json
{
  "assistants": [{...}, {...}]
}
```

But the API actually returns:
```json
[{...}, {...}]
```

This caused a JSON decode error: `"invalid type: map, expected a sequence"`

## Changes

- Updated `AssistantClient::search()` to deserialize the response as `Vec<Assistant>` directly
- Removed the unnecessary `SearchAssistantsResponse` wrapper struct
- Added clarifying comment explaining the difference from the list endpoint

## Related Issues

Fixes #128

Discovered during: #94 (Phase 5: Integration Testing)
Parent Epic: #83 (LangGraph Deployment Assistants Support v0.2.0)

## Test Plan

- ✅ All SDK unit tests pass (22 tests)
- ✅ Code compiles without warnings
- ✅ Clippy checks pass
- ✅ Code is properly formatted

Integration tests require deployment and credentials, which were used to discover this issue in #94.

## Impact

- **CRITICAL**: This fix unblocks the `langstar assistant search` CLI command
- Search functionality is a key feature for the v0.2.0 assistants support

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)