### PR TITLE
🩹 fix(cli): resolve clap short flag conflict in assistant delete command

### DIFF
--- a/cli/src/commands/assistant.rs
+++ b/cli/src/commands/assistant.rs
@@ -105,7 +105,7 @@ pub enum AssistantCommands {
         assistant_id: String,
 
         /// Skip confirmation prompt
-        #[arg(short, long)]
+        #[arg(short = 'y', long)]
         force: bool,
     },
 }


### PR DESCRIPTION
## Summary

Fixes the clap configuration panic that occurred when running `assistant delete` command. The issue was caused by both the `--force` and `--format` flags trying to use the same short flag `-f`.

## Changes

- Modified `cli/src/commands/assistant.rs:108`
- Changed `force` flag from `#[arg(short, long)]` to `#[arg(short = 'y', long)]`
- The `force` flag now uses `-y` instead of `-f`, following common CLI convention for confirmation prompts

## Technical Details

**Before:**
```rust
#[arg(short, long)]
force: bool,
```

**After:**
```rust
#[arg(short = 'y', long)]
force: bool,
```

This resolves the conflict where clap would panic with:
```
Command delete: Short option names must be unique for each argument, 
but '-f' is in use by both 'force' and 'format'
```

## Test Plan

- [x] Verified no panic when running `langstar assistant delete --help`
- [x] Confirmed `-f` is exclusively used for `--format` flag
- [x] Confirmed `-y` is now used for `--force` flag
- [x] All unit tests pass (23 SDK + 17 CLI = 40 tests)
- [x] Code formatting verified with `cargo fmt --check`
- [x] Clippy checks pass with `cargo clippy --workspace --all-features -- -D warnings`
- [x] Workspace compilation successful with `cargo check --workspace --all-features`

## Related Issues

Fixes #131

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)