### PR TITLE
📚 docs: clarify that LangSmith API key is used for both services

### DIFF
--- a/.devcontainer/.env.default
+++ b/.devcontainer/.env.default
@@ -99,11 +99,9 @@ CLAUDE_CODE_USE_BEDROCK=1
 CLAUDE_CODE_MAX_OUTPUT_TOKENS=4096
 MAX_THINKING_TOKENS=1024
 
-# LangSmith Configuration
+# LangChain API Configuration
+# Both LangSmith and LangGraph Cloud use the same API key for authentication
 LANGSMITH_API_KEY=your_langsmith_api_key_here
-
-# LangGraph uses the same API key as LangSmith
-LANGGRAPH_API_KEY=your_langsmith_api_key_here
 
 # Organization and Workspace Scoping (optional)
 # Set these to scope operations to a specific organization or workspace

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -53,15 +53,13 @@ services:
       AWS_REGION: ${AWS_REGION:-us-east-1}
       CLAUDE_CODE_USE_BEDROCK: ${CLAUDE_CODE_USE_BEDROCK:-1}
 
-      # LangSmith Configuration
+      # LangChain API Configuration
+      # Both LangSmith and LangGraph Cloud use LANGSMITH_API_KEY for authentication
       LANGSMITH_API_KEY: ${LANGSMITH_API_KEY}
       LANGSMITH_ORGANIZATION_NAME: ${LANGSMITH_ORGANIZATION_NAME}
       LANGSMITH_ORGANIZATION_ID: ${LANGSMITH_ORGANIZATION_ID}
       LANGSMITH_WORKSPACE_NAME: ${LANGSMITH_WORKSPACE_NAME}
       LANGSMITH_WORKSPACE_ID: ${LANGSMITH_WORKSPACE_ID}
-
-      # LangGraph Configuration (uses same API key as LangSmith)
-      LANGGRAPH_API_KEY: ${LANGGRAPH_API_KEY}
       LANGCHAIN_WORKSPACE_ID: ${LANGCHAIN_WORKSPACE_ID}
 
       # Test LangGraph Deployment (for Phase 5 integration testing)


### PR DESCRIPTION
## Summary

Clarifies that both LangSmith and LangGraph Cloud use the same `LANGSMITH_API_KEY` for authentication, eliminating confusion from the redundant `LANGGRAPH_API_KEY` variable.

## Changes

- **Remove** redundant `LANGGRAPH_API_KEY` from `.devcontainer/.env.default`
- **Update** comments to clarify unified authentication
- **Simplify** docker-compose.yml environment configuration

## Why This Change

The PR #142 comment pointed out that we only use `LANGSMITH_API_KEY` for authentication across both services. The separate `LANGGRAPH_API_KEY` variable was confusing and redundant, as LangGraph Cloud uses the same authentication as LangSmith.

## Before

```bash
# LangSmith Configuration
LANGSMITH_API_KEY=your_langsmith_api_key_here

# LangGraph uses the same API key as LangSmith
LANGGRAPH_API_KEY=your_langsmith_api_key_here
```

## After

```bash
# LangChain API Configuration
# Both LangSmith and LangGraph Cloud use the same API key for authentication
LANGSMITH_API_KEY=your_langsmith_api_key_here
```

## Testing

- [x] Verified documentation is clearer
- [x] No functional changes to code behavior
- [x] Simplified configuration reduces confusion

## Related

Addresses feedback on PR #142

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>