### PR TITLE
🔧 build(devcontainer): use Claude native installer instead of npm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -98,8 +98,10 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
   -x
 
-# Install Claude
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+# Install Claude using native installer (recommended method)
+# https://code.claude.com/docs/en/setup.md
+# Using wget (already available) instead of curl for security
+RUN wget -qO- https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
 
 # --------------------↑-FROM CLAUDE CODE DEVCONTAINER-↑--------------------
 


### PR DESCRIPTION
## Summary

Replaces npm installation of Claude Code with the official native installer method as recommended in the [Claude Code installation documentation](https://code.claude.com/docs/en/setup.md).

## Changes

- **Updated `.devcontainer/Dockerfile:105`**: Replaced `npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}` with native installer using `wget`
- **Security-conscious approach**: Uses `wget` (already available in base image) instead of `curl` to avoid adding unnecessary dependencies
- **Added documentation**: Included reference to official docs and rationale in comments

## Benefits

- **Self-contained executable**: No Node.js dependency required
- **Improved stability**: Better auto-updater according to official docs
- **Best practices**: Uses the officially recommended installation method
- **Security**: No additional dependencies added - uses existing `wget` from base image
- **Explicit dependencies**: Follows project principle of "Specific and Explicit are better than Implicit and vague"

## Security Consideration

Instead of adding `curl` (which would expand the security surface area), this implementation uses `wget` which is already present in the base image (`mcr.microsoft.com/vscode/devcontainers/typescript-node`). The command `wget -qO-` is equivalent to `curl -fsSL`:
- `-q` = quiet/silent mode
- `-O-` = output to stdout
- wget follows redirects and fails on errors by default

## Related Issues

Fixes #125

## Test Plan

- [ ] Rebuild devcontainer to verify Claude Code installs successfully
- [ ] Verify Claude Code command works: `claude --version`
- [ ] Verify `CLAUDE_CODE_VERSION` ARG still works correctly
- [ ] Test basic Claude Code functionality

## Additional Notes

The `CLAUDE_CODE_VERSION` ARG continues to work with the native installer - it accepts version strings like `latest` or specific versions like `1.0.58`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>