### PR TITLE
🩹 fix(ci): use install-action for git-cliff installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,9 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Install git-cliff
-        run: |
-          wget -q https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-$(uname -m)-unknown-linux-gnu.tar.gz
-          tar -xzf git-cliff-$(uname -m)-unknown-linux-gnu.tar.gz
-          chmod +x git-cliff
-          sudo mv git-cliff /usr/local/bin/
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## Problem

The v0.3.0 release workflow failed during git-cliff installation:
https://github.com/codekiln/langstar/actions/runs/19301598596/job/55197331169

The previous approach tried to download:
```
https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz
```

But git-cliff release assets include the version in the filename:
```
git-cliff-2.10.1-x86_64-unknown-linux-gnu.tar.gz
```

This caused a 404 error (exit code 8).

## Solution

Use [`taiki-e/install-action@v2`](https://github.com/taiki-e/install-action) which:
- ✅ Downloads pre-built binaries efficiently
- ✅ Handles version resolution automatically
- ✅ Works reliably across platforms
- ✅ Is faster than `cargo install`
- ✅ Widely used in Rust CI/CD workflows

## Changes

```diff
- name: Install git-cliff
-  run: |
-    wget -q https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-$(uname -m)-unknown-linux-gnu.tar.gz
-    tar -xzf git-cliff-$(uname -m)-unknown-linux-gnu.tar.gz
-    chmod +x git-cliff
-    sudo mv git-cliff /usr/local/bin/
+  uses: taiki-e/install-action@v2
+  with:
+    tool: git-cliff
```

## Testing

After merging, we can re-run the v0.3.0 release by:
1. Deleting the failed v0.3.0 tag and release
2. Re-pushing the v0.3.0 tag

Or simply push a new v0.3.1 tag.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)