### PR TITLE
🩹 fix(config): update cliff.toml to use commit.remote instead of commit.github

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -26,7 +26,7 @@ body = """
     {% for commit in commits %}
         - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
             {{ commit.message | upper_first | trim }}\
-            {% if commit.github.pr_number %} ([#{{ commit.github.pr_number }}]({{ commit.github.pr_url }})){% endif %}\
+            {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ commit.remote.pr_url }})){% endif %}\
     {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
## Problem

The v0.3.0 release workflow failed again during changelog generation:
https://github.com/codekiln/langstar/actions/runs/19302142148/job/55199334302

Error:
```
ERROR git_cliff - Template render error:
Variable 'commit.github.pr_url' not found in context while rendering 'body'
```

The git-cliff configuration is using deprecated variables:
- `commit.github.pr_number`
- `commit.github.pr_url`

## Solution

Update `cliff.toml` to use the new `commit.remote` variables:

```diff
-            {% if commit.github.pr_number %} ([#{{ commit.github.pr_number }}]({{ commit.github.pr_url }})){% endif %}
+            {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ commit.remote.pr_url }})){% endif %}
```

This aligns with git-cliff's current API and resolves the deprecation warning:
```
WARN Variables ["commit.github", "commit.gitea", "commit.gitlab", "commit.bitbucket"] 
     are deprecated and will be removed in the future. Use 'commit.remote' instead.
```

## Changes

- Updated template in `cliff.toml` to use `commit.remote.*` variables

## Testing

After merging, we'll retry the v0.3.0 release by:
1. Deleting the failed v0.3.0 tag
2. Re-pushing the v0.3.0 tag

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)