### PR TITLE
🩹 fix(ci): provide GITHUB_TOKEN to git-cliff for PR data

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git-cliff --latest --strip header > CHANGELOG_ENTRY.md
           echo "Changelog generated:"


### PR DESCRIPTION
## Problem

The v0.3.0 release workflow failed **again** during changelog generation:
https://github.com/codekiln/langstar/actions/runs/19302490575/job/55200586683

Error:
```
ERROR git_cliff - Template render error:
Variable 'commit.remote.pr_url' not found in context while rendering 'body'
```

## Root Cause

The `cliff.toml` template references `commit.remote.pr_number` and `commit.remote.pr_url`, but git-cliff needs access to the GitHub API to fetch this PR information. Without a GitHub token, these variables are unavailable.

## Solution

Add `GITHUB_TOKEN` to the git-cliff step environment:

```diff
  - name: Generate changelog
    id: changelog
+   env:
+     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    run: |
      git-cliff --latest --strip header > CHANGELOG_ENTRY.md
```

With the token, git-cliff can:
- Fetch PR numbers and URLs for commits
- Populate `commit.remote.pr_number` and `commit.remote.pr_url` variables
- Render the changelog template successfully

## Changes

- Added `GITHUB_TOKEN` environment variable to the "Generate changelog" step

## Testing

After merging, we'll retry the v0.3.0 release (hopefully for the last time\!).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)