### PR TITLE
🩹 fix(config): remove PR links from cliff.toml template

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -24,9 +24,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}
-        - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
-            {{ commit.message | upper_first | trim }}\
-            {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ commit.remote.pr_url }})){% endif %}\
+        - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first | trim }}\
     {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
## Problem

The v0.3.0 release workflow continues to fail during changelog generation:
https://github.com/codekiln/langstar/actions/runs/19302688482/job/55201654618

Even with `GITHUB_TOKEN` provided, git-cliff cannot reliably populate the `commit.remote.pr_url` and `commit.remote.pr_number` variables.

## Root Cause

git-cliff's GitHub integration appears to have issues fetching PR information, even with proper authentication. The exact cause is unclear, but this is blocking our release.

## Solution

**Simplify the changelog template by removing PR links.**

The commit messages already contain PR numbers (e.g., "add installer script (#149)"), so we're not losing information. We just won't have clickable links to PRs in the generated changelog.

### Before:
```
- **scope**: commit message ([#149](https://github.com/...))
```

### After:
```
- **scope**: commit message
```

The PR numbers are still visible in the commit messages themselves.

## Changes

```diff
-        - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}-            {{ commit.message | upper_first | trim }}-            {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ commit.remote.pr_url }})){% endif %}+        - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first | trim }}```

## Testing

After merging, we'll retry the v0.3.0 release. This should finally work since we're removing the problematic template variables.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)