### PR TITLE
🩹 fix(ci): add contents: write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ steps.get_version.outputs.version }}
@@ -59,6 +61,8 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: create-release
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The v0.3.0 release workflow failed with a **permission error** when trying to create the GitHub release:
https://github.com/codekiln/langstar/actions/runs/19302810797/job/55203138883

Error:
```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration"}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
```

**Good news:** The changelog generation finally succeeded! We're past all the git-cliff issues. Now it's just a permissions problem.

## Root Cause

The workflow uses `GITHUB_TOKEN` but doesn't explicitly request `contents: write` permission. GitHub Actions has been tightening security, and workflows now need explicit permission grants.

## Solution

Add `permissions: contents: write` to both jobs:

```yaml
jobs:
  create-release:
    permissions:
      contents: write  # Needed to create GitHub release
    
  build-release:
    permissions:
      contents: write  # Needed to upload release assets
```

## Changes

- Added `permissions.contents: write` to `create-release` job
- Added `permissions.contents: write` to `build-release` job

## References

- [GitHub Actions permissions documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

## Testing

After merging, we'll retry the v0.3.0 release. With permissions fixed, it should complete successfully.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)