### PR TITLE
📚 docs: add alpha status indicator to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![CI](https://github.com/codekiln/langstar/workflows/CI/badge.svg)](https://github.com/codekiln/langstar/actions)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Status](https://img.shields.io/badge/status-alpha-orange.svg)](https://github.com/codekiln/langstar/issues)
+
+> **⚠️ Alpha Status**: This project is in early development. APIs and features may change. Use with caution in production environments.
 
 **Langstar** is a unified Rust CLI for the LangChain ecosystem, providing ergonomic access to LangSmith, LangGraph Cloud, and other LangChain services.
 


### PR DESCRIPTION
## Summary
Added a prominent alpha status indicator to the README to clearly communicate that the project is in early development.

## Changes
- Added alpha status badge alongside existing CI and License badges
- Added a prominent warning notice section explaining the project's alpha status
- Clarified that APIs and features may change

## Related Issues
Fixes #165

## Test Plan
- [x] Verified the badge displays correctly in the README
- [x] Confirmed the warning notice is prominent and clear
- [x] Reviewed formatting and alignment with existing badges

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)