### PR TITLE
✨ feat(ci): add GitHub Action to build test Docker image

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -1,0 +1,41 @@
+name: Build Test Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cli/tests/fixtures/test-graph-deployment/**'
+      - '.github/workflows/build-test-image.yml'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write  # Required for GHCR push
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push test image
+        uses: docker/build-push-action@v5
+        with:
+          context: cli/tests/fixtures/test-graph-deployment
+          push: true
+          tags: ghcr.io/codekiln/langstar:test-latest
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Creates GitHub Action workflow to build and push test fixture Docker image to GitHub Container Registry (GHCR) for use in integration tests.

## Changes

- Added `.github/workflows/build-test-image.yml` workflow
- Builds Docker image from `cli/tests/fixtures/test-graph-deployment/`
- Pushes to `ghcr.io/codekiln/langstar:test-latest`
- Uses built-in `GITHUB_TOKEN` for authentication (no secrets setup needed)
- Triggers on push to main or manual workflow_dispatch
- Single platform: linux/amd64 (sufficient for LangGraph Cloud)
- Implements GitHub Actions cache for faster builds

## Configuration

**Permissions required:** `packages: write` (already in workflow)

**Image Registry:** GitHub Container Registry (ghcr.io)
- Free for both public and private images
- No rate limits (unlike Docker Hub's 200 pulls/6 hours)
- Built-in authentication via GITHUB_TOKEN
- No separate secrets configuration needed

## Next Steps

After this PR merges:
1. Verify image visibility in GitHub Packages settings (should be public)
2. Workflow will run on next push to main
3. Image will be available at `ghcr.io/codekiln/langstar:test-latest`
4. Integration tests can be updated to use external_docker deployments

## Related Issues

Fixes #172

Sub-issue of #171

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)