### PR TITLE
🧪 test: add deployment workflow test helpers and reusable test deployment

### DIFF
--- a/sdk/tests/integration_deployment_workflow.rs
+++ b/sdk/tests/integration_deployment_workflow.rs
@@ -19,7 +19,7 @@ struct DeploymentGuard {
 
 impl DeploymentGuard {
     /// Create a new deployment guard
-    fn new(_client: &LangchainClient, deployment_id: String) -> Self {
+    fn new(deployment_id: String) -> Self {
         Self {
             deployment_id,
             armed: true,
@@ -409,7 +409,7 @@ async fn test_deployment_workflow_full_lifecycle() {
     println!();
 
     // Create RAII guard for automatic cleanup on failure
-    let mut guard = DeploymentGuard::new(&client, deployment_id.clone());
+    let mut guard = DeploymentGuard::new(deployment_id.clone());
 
     // Validate deployment creation response
     assert_eq!(


### PR DESCRIPTION
## Summary

Adds comprehensive test helpers and documentation for deployment workflow integration tests, implementing a reusable test deployment pattern to optimize test execution time.

## Changes

### Test Helpers (sdk/tests/integration_deployment_workflow.rs)
- **Helper test functions**: Added `test_deployment_list_helper`, `test_deployment_get_helper`, `test_deployment_delete_helper`
- **DeploymentGuard**: Implemented RAII pattern with warning-based cleanup for automatic deployment lifecycle management
- **Reusable test deployment**: Main test now uses `langstar-integration-test` with get-or-create pattern
  - First run: ~22 minutes (creates deployment)
  - Subsequent runs: ~6 minutes (reuses deployment)
  - 73% time reduction for iterative development
- **Full lifecycle test**: Added `test_deployment_workflow_full_lifecycle` for pre-release validation

### Documentation (sdk/tests/README.md)
- **Test execution guide**: Environment variables, running tests, troubleshooting
- **Test categories**: Organization overview and detailed test descriptions
- **Integration test best practices**: CI/CD compatibility, test isolation, patterns
- **Cleanup procedures**: Manual and automated deployment cleanup

## Test Plan

- [x] All helper tests pass individually
- [x] Main workflow test passes with reusable deployment (~6 min)
- [x] Full lifecycle test passes with create/delete (~22 min)
- [x] Pre-commit checks pass (fmt, check, clippy, test)
- [x] Code compiles successfully
- [x] Documentation is comprehensive and accurate

## Related Issues

Fixes #186

## Follow-up Work

Created issues for future enhancements:
- #187: Claude skill for running tests in worktrees with env var handling
- #188: Deployment management subagent for listing/cleanup

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>