### PR TITLE
🩹 fix(ci): align release workflow artifact naming for upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,13 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             artifact_name: langstar
-            asset_name: langstar-$VERSION-x86_64-linux-musl
+            asset_platform: x86_64-linux-musl
 
           # macOS ARM64 (Apple Silicon)
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact_name: langstar
-            asset_name: langstar-$VERSION-aarch64-macos
+            asset_platform: aarch64-macos
 
           # TODO: Add more platforms after these two work
           # - x86_64-unknown-linux-gnu (Linux gnu)
@@ -116,8 +116,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
-          ASSET_NAME="${{ matrix.asset_name }}"
-          ASSET_NAME="${ASSET_NAME/\$VERSION/${{ needs.create-release.outputs.version }}}"
+          ASSET_NAME="langstar-${{ needs.create-release.outputs.version }}-${{ matrix.asset_platform }}"
           tar czf "$ASSET_NAME.tar.gz" ${{ matrix.artifact_name }}
           shasum -a 256 "$ASSET_NAME.tar.gz" > "$ASSET_NAME.tar.gz.sha256"
           mv "$ASSET_NAME.tar.gz" "$ASSET_NAME.tar.gz.sha256" ../../..
@@ -127,8 +126,7 @@ jobs:
         shell: bash
         run: |
           cd target/${{ matrix.target }}/release
-          ASSET_NAME="${{ matrix.asset_name }}"
-          ASSET_NAME="${ASSET_NAME/\$VERSION/${{ needs.create-release.outputs.version }}}"
+          ASSET_NAME="langstar-${{ needs.create-release.outputs.version }}-${{ matrix.asset_platform }}"
           7z a "$ASSET_NAME.zip" ${{ matrix.artifact_name }}
           sha256sum "$ASSET_NAME.zip" > "$ASSET_NAME.zip.sha256"
           mv "$ASSET_NAME.zip" "$ASSET_NAME.zip.sha256" ../../..
@@ -139,8 +137,8 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: |
-            ${{ matrix.asset_name }}-${{ needs.create-release.outputs.version }}.tar.gz
-            ${{ matrix.asset_name }}-${{ needs.create-release.outputs.version }}.tar.gz.sha256
+            langstar-${{ needs.create-release.outputs.version }}-${{ matrix.asset_platform }}.tar.gz
+            langstar-${{ needs.create-release.outputs.version }}-${{ matrix.asset_platform }}.tar.gz.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -150,7 +148,7 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: |
-            ${{ matrix.asset_name }}-${{ needs.create-release.outputs.version }}.zip
-            ${{ matrix.asset_name }}-${{ needs.create-release.outputs.version }}.zip.sha256
+            langstar-${{ needs.create-release.outputs.version }}-${{ matrix.asset_platform }}.zip
+            langstar-${{ needs.create-release.outputs.version }}-${{ matrix.asset_platform }}.zip.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixed critical file name mismatch in release workflow preventing binary artifacts from being uploaded to GitHub releases.

## Problem

The release workflow successfully built binaries but never uploaded them:
- v0.4.0, v0.3.0, v0.2.0, v0.1.0 all show "0 assets"
- Workflow logs showed: `🤔 Pattern 'langstar-$VERSION-x86_64-linux-musl-0.4.0.tar.gz' does not match any files`

**Root Cause:**
- Archive creation step substituted `$VERSION` → `langstar-0.4.0-x86_64-linux-musl.tar.gz`
- Upload step referenced unsubstituted variable → `langstar-$VERSION-x86_64-linux-musl-0.4.0.tar.gz`
- File name patterns didn't match → upload silently skipped

## Changes

- Changed matrix variable from `asset_name` to `asset_platform`
- Removed bash string substitution complexity
- Constructed consistent filename pattern: `langstar-{version}-{platform}.tar.gz`
- Applied fix to both Unix and Windows upload steps

## Testing

Next release (v0.4.1) will validate:
- ✅ Binary tar.gz files are uploaded
- ✅ SHA256 checksums are uploaded
- ✅ Files match expected naming pattern
- ✅ Installer script can download binaries

## Related Issues

Fixes #196

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)