### PR TITLE
✨ feat(ci): add CI status verification to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,49 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  verify-ci:
+    name: Verify CI Passed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Check job
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'Check'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
+      - name: Wait for Test job
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'Test'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
+      - name: Wait for Clippy job
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'Clippy'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
+      - name: Wait for Build jobs
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-regexp: 'Build \(.*\)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
   create-release:
     name: Create Release
+    needs: verify-ci
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Adds CI status verification as a quality gate in the release workflow to prevent publishing releases when CI checks fail.

## Changes

- Added `verify-ci` job to `.github/workflows/release.yml`
- Uses `lewagon/wait-on-check-action@v1.3.4` to verify all CI checks passed
- Verifies the following CI jobs before proceeding with release:
  - **Check**: Formatting and compilation checks
  - **Test**: Unit tests
  - **Clippy**: Linting checks
  - **Build**: Multi-platform build verification (using regex to match matrix jobs)
- Made `create-release` job depend on `verify-ci` to block release creation until all checks pass

## How It Works

When a release tag is pushed:
1. Release workflow triggers
2. `verify-ci` job starts and waits for all CI checks to complete on the tagged commit
3. If any CI check fails, the `verify-ci` job fails and the release workflow stops
4. If all CI checks pass, `create-release` job proceeds to create the GitHub release

## Testing Plan

To test this implementation:

1. **Test with passing CI**: 
   - Ensure all CI checks pass on a commit on main
   - Create a test tag on that commit
   - Verify release workflow proceeds normally

2. **Test with failing CI**:
   - Create a commit with intentional test/lint failures
   - Create a test tag on that commit
   - Verify release workflow fails at `verify-ci` step with clear error message

## Related Issues

Fixes #197  
Part of #195 (new-release-epic)

## Notes

- Using `check-regexp: 'Build \(.*\)'` to match matrix build jobs across different platforms
- Set `wait-interval: 10` seconds for polling and `allowed-conclusions: success` to only accept successful checks
- This prevents the scenario where a release could be published with failing tests or lint errors

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>