### PR TITLE
✨ feat(ci): add automatic git tag creation on release PR merge

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -5,10 +5,6 @@ on:
     types: [closed]
     branches: [main]
 
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
-
 jobs:
   auto-tag:
     name: Auto-Tag Release
@@ -28,11 +24,13 @@ jobs:
       - name: Extract version from PR title
         id: version
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
+          # Read PR title safely from GitHub event data (prevents command injection)
+          TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
           echo "PR Title: $TITLE"
 
           # Extract version number (e.g., "🔖 release: bump version to v0.4.1" -> "0.4.1")
-          VERSION=$(echo "$TITLE" | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+')
+          # Uses sed instead of grep -oP for better portability (macOS compatibility)
+          VERSION=$(echo "$TITLE" | sed -n 's/.*v\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
 
           if [ -z "$VERSION" ]; then
             echo "ERROR: Could not extract version from PR title: $TITLE"
@@ -49,8 +47,13 @@ jobs:
         run: |
           echo "Verifying CI checks passed for PR #${{ github.event.pull_request.number }}..."
 
-          # Check that all required CI checks passed
-          # This uses gh pr checks which shows the status of all checks
+          # NOTE: This verifies the CI status from the PR branch before merge.
+          # This is appropriate because GitHub branch protection rules prevent
+          # merging if required checks haven't passed. This step provides an
+          # additional safeguard and clear logging of the pre-merge CI status.
+          #
+          # The workflow runs on the 'pull_request' event with type 'closed',
+          # so we check the PR's checks that ran before the merge occurred.
           gh pr checks ${{ github.event.pull_request.number }} --required || {
             echo "ERROR: Required CI checks did not pass"
             exit 1
@@ -60,11 +63,18 @@ jobs:
 
       - name: Verify version matches Cargo.toml
         run: |
-          CARGO_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          # Extract version from [workspace.package] section for robustness
+          # This explicitly looks for the workspace version to avoid ambiguity
+          CARGO_VERSION=$(awk '/^\[workspace\.package\]/{f=1} f && /^version = /{print; exit}' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           EXPECTED_VERSION="${{ steps.version.outputs.version }}"
 
           echo "Version in Cargo.toml: $CARGO_VERSION"
           echo "Version from PR title: $EXPECTED_VERSION"
+
+          if [ -z "$CARGO_VERSION" ]; then
+            echo "ERROR: Could not extract version from Cargo.toml [workspace.package] section"
+            exit 1
+          fi
 
           if [ "$CARGO_VERSION" != "$EXPECTED_VERSION" ]; then
             echo "ERROR: Version mismatch!"


### PR DESCRIPTION
## Summary

Automatically create and push git tags when release PRs merge to main, eliminating manual tag creation errors and ensuring the release workflow triggers automatically.

## Changes

Created `.github/workflows/auto-tag-release.yml` workflow that:

### Trigger
- Runs when PR closes on main branch  
- Only executes if PR was merged AND title starts with "🔖 release:"

### Workflow Steps

**1. Extract version from PR title**
- Parses version from title (e.g., "🔖 release: bump version to v0.4.1" → "0.4.1")
- Validates version format (X.Y.Z)
- Fails fast if version cannot be extracted

**2. Verify CI passed**
- Uses `gh pr checks --required` to verify all required checks passed
- Prevents tagging if CI failed

**3. Validate version consistency**
- Compares version from PR title with `Cargo.toml`
- Ensures they match before creating tag
- Prevents version mismatch errors

**4. Create and push tag**
- Creates annotated git tag: `vX.Y.Z`
- Uses `github-actions[bot]` as committer
- Pushes tag to origin (triggers release.yml automatically)
- Idempotent: skips if tag already exists

## Benefits

- ✅ Eliminates manual tag creation step
- ✅ Prevents version mismatches between PR title and Cargo.toml  
- ✅ Ensures CI passes before tagging
- ✅ Reduces human error in release process
- ✅ Enables fully automated releases

## Testing Plan

To test this workflow:

1. Create release PR with title: `🔖 release: bump version to vX.Y.Z`
2. Ensure `Cargo.toml` version matches the PR title version
3. Wait for all CI checks to pass
4. Merge the PR
5. Verify:
   - [ ] Tag `vX.Y.Z` created automatically
   - [ ] Tag is annotated (not lightweight)
   - [ ] Release workflow triggered by the tag
   - [ ] GitHub release created successfully

## Related Issues

Fixes #198

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>