### PR TITLE
✨ feat(ci): add GitHub Actions workflow to publish devcontainer features

### DIFF
--- a/.github/workflows/release-features.yaml
+++ b/.github/workflows/release-features.yaml
@@ -1,0 +1,26 @@
+name: "Release dev container features & Generate Documentation"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    # Only allow manual dispatch from main branch
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: "Publish Features"
+        uses: devcontainers/action@v1
+        with:
+          publish-features: "true"
+          base-path-to-features: "./.devcontainer/features"
+          generate-docs: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Implements automated publishing of devcontainer features to GitHub Container Registry (GHCR) using GitHub Actions with manual workflow_dispatch trigger.

## Changes

- Created `.github/workflows/release-features.yaml`
- Configured `workflow_dispatch` for manual triggering
- Set up proper permissions (contents, pull-requests, packages)
- Added `devcontainers/action@v1` publish step
- Configured `base-path-to-features: "./.devcontainer/features"`
- Enabled auto-documentation generation

## Related Issues

Fixes #203

## Technical Details

**Workflow features:**
- Manual trigger only (workflow_dispatch)
- Branch restriction to main branch
- Permissions: contents, pull-requests, packages (all write)
- Uses devcontainers/action@v1 for publishing
- Auto-generates documentation via PR
- Base path: `./.devcontainer/features`

**Next steps:**
After merging to parent branch and eventually to main:
1. Manually trigger the workflow from GitHub Actions tab
2. Verify feature publishes to `ghcr.io/codekiln/langstar/langstar`
3. Make the package public (first publish defaults to private)

## Test Plan

- [x] Created workflow file with correct syntax
- [x] Configured all required permissions
- [x] Set proper base-path-to-features
- [ ] Test manual workflow dispatch (after merge to main)
- [ ] Verify feature appears in GHCR (after workflow run)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>