### PR TITLE
✨ feat(ci): add workflow_dispatch to automate release PR generation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install Python dependencies
+        run: |
+          pip install toml
+
       - name: Install git-cliff
         uses: taiki-e/install-action@v2
         with:
@@ -45,19 +49,18 @@ jobs:
         run: |
           set -euo pipefail  # Exit on error, undefined variables, and pipe failures
 
-          # Get current version from root Cargo.toml ([workspace.package] section)
-          CURRENT=$(awk '/^\[workspace\.package\]/{f=1} f && /^version = /{print; exit}' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          # Get current version from root Cargo.toml using Python TOML parser
+          CURRENT=$(python3 -c "import toml; print(toml.load(open('Cargo.toml'))['workspace']['package']['version'])")
           echo "current=$CURRENT" >> $GITHUB_OUTPUT
 
           # Determine bump type
           BUMP_TYPE="${{ github.event.inputs.bump }}"
 
           if [ "$BUMP_TYPE" = "auto" ]; then
-            # Use Python script to analyze commits and capture exit code
+            # Use Python script to analyze commits (only use exit code, not stdout)
             set +e  # Temporarily disable exit on error to capture exit code
             python3 .claude/skills/bump-release/scripts/analyze_commits.py \
-              --current-version "$CURRENT" \
-              --format bump-type
+              --current-version "$CURRENT" > /dev/null
             BUMP_TYPE_AUTO=$?
             set -e  # Re-enable exit on error
 
@@ -77,6 +80,15 @@ jobs:
           CURRENT_CLEAN="${CURRENT#v}"  # Remove 'v' prefix if present
           CURRENT_CLEAN="${CURRENT_CLEAN%%[-+]*}"  # Remove pre-release/build metadata
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_CLEAN"
+
+          # Validate that MAJOR, MINOR, PATCH are all non-empty and integers
+          for var_name in MAJOR MINOR PATCH; do
+            var_value="${!var_name}"
+            if ! [[ "$var_value" =~ ^[0-9]+$ ]]; then
+              echo "Error: Version component '$var_name' is invalid ('$var_value') in version '$CURRENT_CLEAN'"
+              exit 1
+            fi
+          done
 
           case $BUMP_TYPE in
             major)
@@ -146,6 +158,9 @@ jobs:
         if: steps.check_bump.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@v5
         with:
+          # NOTE: Using secrets.GITHUB_TOKEN will NOT trigger other workflows (like CI) on the created PR
+          # due to GitHub's security restrictions to prevent recursive workflow triggers.
+          # If you want CI to run automatically on release PRs, use a Personal Access Token (PAT) instead.
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/v${{ steps.version.outputs.new }}
           delete-branch: true


### PR DESCRIPTION
## Summary

Implements Phase 3 of the release epic (#195) - automated release PR creation via GitHub Actions workflow_dispatch.

## Changes

### New Workflow: `.github/workflows/prepare-release.yml`

**Trigger**: Manual workflow_dispatch in GitHub Actions UI

**Inputs**:
- `bump` (choice): Version bump type - auto (default), major, minor, or patch

**Functionality**:
1. **Analyzes commits** since last release using Conventional Emoji Commits parser
2. **Determines version bump** automatically or uses specified bump type
3. **Updates all Cargo.toml files** in workspace using Python script
4. **Updates Cargo.lock** by running `cargo check --workspace`
5. **Generates changelog** using git-cliff
6. **Creates PR** with proper metadata and labels

**Smart behavior**:
- Skips PR creation if no releasable commits found (bump type = "none")
- Updates all workspace members to same version
- Updates workspace dependency references
- Uses existing cliff.toml configuration

## Success Criteria Met

- ✅ GitHub UI has "Prepare Release" workflow button (workflow_dispatch)
- ✅ Clicking button creates release PR automatically
- ✅ Version determined from Conventional Emoji Commits (auto mode)
- ✅ All Cargo.toml files updated (workspace-wide)
- ✅ Changelog generated with git-cliff
- ✅ PR ready for review and CI checks

## Testing

### How to Test

1. **Navigate to GitHub Actions**:
   - Go to: https://github.com/codekiln/langstar/actions
   - Find "Prepare Release" workflow

2. **Run workflow manually**:
   - Click "Run workflow" button
   - Select branch: `codekiln/199-automate-release-pr-creation`
   - Choose bump type: `auto` (recommended for testing)
   - Click "Run workflow"

3. **Verify PR creation**:
   - Check that a new PR is created with title: `🔖 release: bump version to vX.Y.Z`
   - Verify Cargo.toml files are updated
   - Review generated CHANGELOG.md
   - Confirm CI checks pass

### Expected Behavior

**If releasable commits exist** (feat/fix/perf):
- PR created with version bump
- All Cargo.toml files updated
- CHANGELOG.md updated with new entry
- PR labeled with `release` and `automated`

**If no releasable commits** (only docs/test/refactor):
- Workflow runs but skips PR creation
- Warning message: "No releasable commits found"
- No changes made

### Manual Testing Commands (Optional)

Test the Python scripts locally:

```bash
# Test commit analysis
python3 .claude/skills/bump-release/scripts/analyze_commits.py \
  --format json --verbose

# Test version bump (dry-run)
python3 .claude/skills/bump-release/scripts/bump_version.py \
  0.2.1 --dry-run --workspace-deps --verbose
```

## Integration with Release Epic

This PR completes Phase 3 of the release epic:

- ✅ Phase 0 (#196): Fix binary upload - DONE
- ✅ Phase 1 (#197): CI verification - DONE
- ✅ Phase 2 (#198): Auto-tag on PR merge - DONE
- ✅ **Phase 3 (#199): Automate release PR creation - THIS PR**
- 🔲 Phase 4 (#200): Test installer script - NEXT
- 🔲 Phase 5 (#207): Add validation tests

### Workflow Integration

After this PR is merged:

1. **Developer workflow** (manual release):
   - Go to Actions → "Prepare Release"
   - Click "Run workflow"
   - Select bump type (auto/major/minor/patch)
   - Review and merge generated PR
   - Phase 2 auto-tags on merge → triggers binary build (#198)

2. **Automated flow** (once #200 is done):
   - Commit changes with conventional commits
   - Workflow creates release PR automatically
   - Review and merge PR
   - Auto-tag triggers (#198) → binary build
   - Installer script validates release (#200)

## Related Issues

Fixes #199 (Phase 3: Automate release PR creation)
Sub-task of #195 (Release epic)
Depends on #198 (Auto-tag workflow - already merged)

## Notes

- Python scripts are reused from `.claude/skills/bump-release/scripts/`
- Uses existing `cliff.toml` configuration for changelog formatting
- Follows Conventional Emoji Commits spec for version determination
- PR format follows project commit conventions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>