### PR TITLE
🩹 fix(ci): fix workspace version update in prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -130,12 +130,15 @@ jobs:
 
           NEW_VERSION="${{ steps.version.outputs.new }}"
 
-          # Use Python script to update all Cargo.toml files
-          python3 .claude/skills/bump-release/scripts/bump_version.py \
-            "$NEW_VERSION" \
-            --root . \
-            --workspace-deps \
-            --verbose
+          # Update version in [workspace.package] section of root Cargo.toml
+          # Workspace members inherit this version via version.workspace = true
+          sed -i.bak -E '/^\[workspace\.package\]/,/^\[/ s/^version = "[^"]+"/version = "'"$NEW_VERSION"'"/' Cargo.toml
+          rm Cargo.toml.bak
+
+          echo "Updated root Cargo.toml [workspace.package] version to $NEW_VERSION"
+
+          # Verify the update
+          grep -A 5 '^\[workspace\.package\]' Cargo.toml | grep version
 
       - name: Update Cargo.lock
         if: steps.check_bump.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Fixes the workflow failure from the first test run where bump_version.py couldn't find versions in CLI and SDK Cargo.toml files.

## Issue

Workspace members use `version.workspace = true` to inherit from root `[workspace.package]` section. The Python script looks for `[package]` version fields which don't exist in members.

## Solution

Use `sed` to directly update `[workspace.package]` version in root Cargo.toml. Members automatically inherit the new version via workspace inheritance.

This is simpler and correct for workspace-based projects.

## Fixes

Workflow run failure: https://github.com/codekiln/langstar/actions/runs/19584495703

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>