### PR TITLE
🩹 fix(ci): add --unreleased flag to git-cliff command

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -163,7 +163,8 @@ jobs:
           NEW_VERSION="${{ steps.version.outputs.new }}"
 
           # Use git-cliff's prepend mode to properly update CHANGELOG.md
-          git-cliff --tag "v$NEW_VERSION" --prepend CHANGELOG.md
+          # --unreleased flag includes commits since last tag
+          git-cliff --tag "v$NEW_VERSION" --unreleased --prepend CHANGELOG.md
 
       - name: Create Pull Request
         if: steps.check_bump.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Fixes the workflow failure in the "Generate changelog" step where git-cliff was missing a required flag.

## Error

From workflow run: https://github.com/codekiln/langstar/actions/runs/19594264425/job/56116776302

```
ERROR git_cliff > Argument error: `'-u' or '-l' is not specified`
```

## Fix

Added `--unreleased` flag to the git-cliff command:

```yaml
git-cliff --tag "v$NEW_VERSION" --unreleased --prepend CHANGELOG.md
```

## Why

git-cliff requires either `-u`/`--unreleased` or `-l`/`--latest` when using `--prepend` mode. The `--unreleased` flag includes all commits since the last tag, which is what we want for a new release.

## Related

Fixes #199

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>