### PR TITLE
🩹 fix(ci): use PAT to trigger CI checks on release PRs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -170,10 +170,10 @@ jobs:
         if: steps.check_bump.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          # NOTE: Using secrets.GITHUB_TOKEN will NOT trigger other workflows (like CI) on the created PR
-          # due to GitHub's security restrictions to prevent recursive workflow triggers.
-          # If you want CI to run automatically on release PRs, use a Personal Access Token (PAT) instead.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT to trigger CI workflows on the created PR
+          # Requires RELEASE_PAT secret with repo permissions
+          # See: https://github.com/settings/tokens/new?scopes=repo&description=Release%20PR%20Creation
+          token: ${{ secrets.RELEASE_PAT }}
           branch: release/v${{ steps.version.outputs.new }}
           delete-branch: true
           title: '🔖 release: bump version to v${{ steps.version.outputs.new }}'


### PR DESCRIPTION
## Problem

Release PRs created by the workflow have **no CI checks**, violating the epic requirement.

From epic #195:
> **3. All CI checks must pass on release PR**

From PR #226 (created by workflow):
- ❌ No CI checks run
- ❌ No format/test/clippy validation
- ❌ Could merge broken code

### Root Cause

Using `GITHUB_TOKEN` prevents workflows from triggering on created PRs (GitHub security restriction).

## Solution

Use `RELEASE_PAT` secret instead of `GITHUB_TOKEN`:

```yaml
token: ${{ secrets.RELEASE_PAT }}
```

This allows CI workflow to run on release PRs, ensuring:
- ✅ Format checks
- ✅ Tests pass
- ✅ Clippy lints
- ✅ Build succeeds

## Setup Required

Before merging, create and configure PAT:

### 1. Create Personal Access Token

Go to: https://github.com/settings/tokens/new?scopes=repo&description=Release%20PR%20Creation

- **Scopes**: `repo` (full control of private repositories)
- **Description**: Release PR Creation
- **Expiration**: Your choice (recommend 90 days or no expiration for automation)

### 2. Add to Repository Secrets

1. Go to: https://github.com/codekiln/langstar/settings/secrets/actions
2. Click "New repository secret"
3. Name: `RELEASE_PAT`
4. Value: Paste the token
5. Click "Add secret"

### 3. Test

After setup, run the workflow again:
1. Actions → Prepare Release → Run workflow
2. Verify PR is created
3. **Verify CI checks run automatically**

## Related

Fixes #199

Depends on PAT being created (one-time setup)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>