### PR TITLE
🩹 fix(install): test and fix installer script with versioned releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install the latest release with our installer script:
 
 ```bash
 # Quick install (recommended)
-curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/codekiln/langstar/main/scripts/install.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/codekiln/langstar/main/scripts/install.sh | bash
 ```
 
 Or download and run manually:
@@ -38,7 +38,7 @@ chmod +x install.sh
 **Install options:**
 ```bash
 # Install specific version
-./install.sh --version 0.2.0
+./install.sh --version 0.4.3
 
 # Install to custom location
 ./install.sh --prefix ~/.local/bin
@@ -50,7 +50,7 @@ chmod +x install.sh
 The installer script:
 - ✅ Downloads pre-built binaries (no compilation needed)
 - ✅ Verifies SHA256 checksums
-- ✅ Supports Linux (x86_64) and macOS (Intel/Apple Silicon)
+- ✅ Supports Linux (x86_64, aarch64) and macOS (Intel/Apple Silicon)
 - ✅ Installs to `/usr/local/bin` or `~/.local/bin`
 - ✅ Handles updates automatically
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # https://github.com/codekiln/langstar
 #
 # Usage:
-#   curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/codekiln/langstar/main/scripts/install.sh | sh
+#   curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/codekiln/langstar/main/scripts/install.sh | bash
 #
 # Or download and run:
 #   curl -LO https://raw.githubusercontent.com/codekiln/langstar/main/scripts/install.sh
@@ -47,11 +47,11 @@ fi
 
 # Output functions
 info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
+    echo -e "${GREEN}[INFO]${NC} $1" >&2
 }
 
 warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
+    echo -e "${YELLOW}[WARN]${NC} $1" >&2
 }
 
 error() {
@@ -59,7 +59,7 @@ error() {
 }
 
 success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
+    echo -e "${GREEN}[SUCCESS]${NC} $1" >&2
 }
 
 die() {


### PR DESCRIPTION
## Summary
Tested the installer script comprehensively with GitHub releases and fixed a critical bug that prevented automatic version detection from working.

## Problem Found
When using the installer without specifying `--version`, the script would fetch the latest version from GitHub API, but the info messages were being captured in command substitutions, corrupting the version string and causing downloads to fail.

## Solution
Redirected all output functions (info, warn, success) to stderr to prevent their output from interfering with command substitutions. This matches the existing behavior of the error() function.

## Changes Made
- **scripts/install.sh**:
  - Fixed bug: Redirect info(), warn(), success() to stderr (>&2)
  - Updated usage comment to use `bash` instead of `sh` (script requires bash-specific syntax like `[[`)
- **README.md**:
  - Updated install command from `sh` to `bash`
  - Updated example version from 0.2.0 to 0.4.3
  - Added aarch64 to supported Linux architectures

## Testing Performed
All tests performed on Linux aarch64 (devcontainer):

✅ **Asset Naming Verification**
- Verified install.sh naming matches release assets (langstar-{version}-{platform}.tar.gz)

✅ **Installation Tests**
- Default install (latest version with automatic detection)
- Version-specific install (--version 0.4.3)
- Custom prefix install (--prefix /tmp/test/install)
- Checksum validation (SHA256)
- Binary functionality verification (--version, --help)
- One-line curl | bash install

✅ **Platform Support**
- Tested on Linux aarch64-musl
- Verified platform detection logic
- Confirmed all release assets are accessible

## Release Asset Verification
Latest release (v0.4.3) includes all required assets:
- langstar-0.4.3-aarch64-linux-musl.tar.gz + .sha256
- langstar-0.4.3-x86_64-linux-musl.tar.gz + .sha256
- langstar-0.4.3-aarch64-macos.tar.gz + .sha256

## Success Criteria Met
- ✅ One-line install works: `curl ... | bash`
- ✅ Version-specific install works
- ✅ Checksums verified automatically
- ✅ Error messages clear and actionable
- ✅ Installation documented in README
- ✅ install.sh matches current asset naming

Fixes #200

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)