### PR TITLE
🩹 fix: Prevent orphaned test deployments in CLI integration tests

### DIFF
--- a/cli/tests/common/fixtures.rs
+++ b/cli/tests/common/fixtures.rs
@@ -134,8 +134,8 @@ impl TestDeployment {
             Some(arr) => arr,
             None => {
                 eprintln!(
-                    "⚠️  Warning: JSON response missing 'resources' array.\nJSON: {}",
-                    json
+                    "⚠️  Warning: JSON response missing 'resources' array.\nJSON keys: {:?}",
+                    json.as_object().map(|obj| obj.keys().collect::<Vec<_>>())
                 );
                 return None;
             }
@@ -152,8 +152,10 @@ impl TestDeployment {
             Some(id) => id.to_string(),
             None => {
                 eprintln!(
-                    "⚠️  Warning: Deployment missing 'id' field.\nDeployment: {}",
+                    "⚠️  Warning: Deployment missing 'id' field.\nAvailable fields: {:?}",
                     deployment
+                        .as_object()
+                        .map(|obj| obj.keys().collect::<Vec<_>>())
                 );
                 return None;
             }
@@ -163,8 +165,10 @@ impl TestDeployment {
             Some(name) => name.to_string(),
             None => {
                 eprintln!(
-                    "⚠️  Warning: Deployment missing 'name' field.\nDeployment: {}",
+                    "⚠️  Warning: Deployment missing 'name' field.\nAvailable fields: {:?}",
                     deployment
+                        .as_object()
+                        .map(|obj| obj.keys().collect::<Vec<_>>())
                 );
                 return None;
             }


### PR DESCRIPTION
Fixes #208

## Summary

Fixed a critical bug in `TestDeployment::find_active_test_deployment()` that was causing orphaned test deployments to be created on every test run.

## Root Cause

The method was attempting to parse the JSON response from `langstar graph list` as a direct array:

```rust
let deployments = json.as_array()?;  // ❌ Always returned None
```

However, the actual JSON structure is:
```json
{
  "resources": [ /* deployments array */ ]
}
```

This meant `as_array()` always failed, returning `None`, which caused the code to create a new deployment every time instead of reusing existing READY deployments.

## Changes

1. **Fixed JSON parsing** (line 111): Changed to access `json["resources"].as_array()`
2. **Added comprehensive error logging**: Replaced silent `.ok()?` failures with explicit error messages that log:
   - Binary build failures
   - Command execution failures
   - JSON parsing errors
   - Missing/malformed JSON fields

## Testing

- ✅ All pre-commit checks pass (fmt, check, clippy, test)
- ✅ Workspace-level tests pass
- ✅ Integration tests complete successfully

## Expected Behavior After Fix

**Before (Bug):**
- Every test run creates a new deployment
- Orphaned deployments accumulate and must be manually cleaned up
- `find_active_test_deployment()` silently fails and returns `None`

**After (Fixed):**
- First test run creates a deployment
- Subsequent test runs reuse the existing READY deployment
- No orphaned deployments created
- Errors are logged with helpful context for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>