### PR TITLE
🩹 fix(cli): use stderr for info messages in JSON mode

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -76,20 +76,31 @@ impl OutputFormatter {
         Ok(())
     }
 
+    /// Helper method to print a message with conditional routing based on format
+    ///
+    /// In JSON mode, outputs to stderr to keep stdout clean for machine-readable JSON.
+    /// This follows the Unix/CLI convention used by cargo, git, curl, etc.
+    fn print_message(&self, icon: impl std::fmt::Display, message: &str) {
+        let formatted = format!("{} {}", icon, message);
+        if self.format == OutputFormat::Json {
+            eprintln!("{}", formatted);
+        } else {
+            println!("{}", formatted);
+        }
+    }
+
     /// Print a success message
     ///
     /// In JSON mode, outputs to stderr to keep stdout clean for machine-readable JSON.
     /// This follows the Unix/CLI convention used by cargo, git, curl, etc.
     #[allow(dead_code)]
     pub fn success(&self, message: &str) {
-        if self.format == OutputFormat::Json {
-            eprintln!("{} {}", "✓".green(), message);
-        } else {
-            println!("{} {}", "✓".green(), message);
-        }
+        self.print_message("✓".green(), message);
     }
 
     /// Print an error message
+    ///
+    /// Error messages always go to stderr regardless of output format.
     #[allow(dead_code)]
     pub fn error(&self, message: &str) {
         eprintln!("{} {}", "✗".red(), message);
@@ -101,11 +112,7 @@ impl OutputFormatter {
     /// This follows the Unix/CLI convention used by cargo, git, curl, etc.
     #[allow(dead_code)]
     pub fn warning(&self, message: &str) {
-        if self.format == OutputFormat::Json {
-            eprintln!("{} {}", "⚠".yellow(), message);
-        } else {
-            println!("{} {}", "⚠".yellow(), message);
-        }
+        self.print_message("⚠".yellow(), message);
     }
 
     /// Print an info message
@@ -113,11 +120,7 @@ impl OutputFormatter {
     /// In JSON mode, outputs to stderr to keep stdout clean for machine-readable JSON.
     /// This follows the Unix/CLI convention used by cargo, git, curl, etc.
     pub fn info(&self, message: &str) {
-        if self.format == OutputFormat::Json {
-            eprintln!("{} {}", "ℹ".blue(), message);
-        } else {
-            println!("{} {}", "ℹ".blue(), message);
-        }
+        self.print_message("ℹ".blue(), message);
     }
 }
 


### PR DESCRIPTION
Fixes #208

## Summary

When `--format json` is used, info/success/warning messages now output to stderr instead of stdout. This keeps stdout clean for machine-readable JSON.

## Root Cause

PR #277 fixed the JSON structure parsing (`json["resources"]` vs `json.as_array()`), but the bug persisted because `OutputFormatter::info()` outputs to stdout regardless of format:

```
ℹ Fetching deployments (limit: 20, offset: 0)...
{"resources": [...]}
```

This caused `serde_json::from_str()` to fail, making `find_active_test_deployment()` return `None` and creating a new deployment on every CI run.

## Solution

Use stderr for info/success/warning messages in JSON mode - the idiomatic Unix/CLI convention used by cargo, git, curl, ripgrep, etc.:

- **stdout** = data stream (for machines/pipes)
- **stderr** = human stream (for status/progress)

## Changes

- `cli/src/output.rs`: Modified `info()`, `success()`, and `warning()` methods to use `eprintln!` when format is `Json`

## Testing

- ✅ `cargo fmt && cargo check --workspace --all-features`
- ✅ `cargo clippy --workspace --all-features -- -D warnings`
- ✅ `cargo test --workspace --all-features --lib`
- ✅ Manual verification: `langstar graph list --format json | jq .` now works

## Before/After

**Before:**
```bash
$ langstar graph list --format json | jq .
parse error: Invalid numeric literal at line 1, column 4
```

**After:**
```bash
$ langstar graph list --format json | jq .
{
  "offset": 1,
  "resources": [...]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)