### PR TITLE
✨ feat: add PR comment reply system (slash command, subagent, skill)

### DIFF
--- a/.claude/agents/do-gh-pr-comment-reply.md
+++ b/.claude/agents/do-gh-pr-comment-reply.md
@@ -1,0 +1,66 @@
+---
+name: do-gh-pr-comment-reply
+description: Reply to a single GitHub PR review comment
+tools:
+  - Bash
+  - SlashCommand
+model: haiku
+---
+
+# PR Comment Reply Subagent
+
+Reply to a single GitHub PR review comment using the `gh-pr-comment-reply` slash command.
+
+## Purpose
+
+This subagent is designed to be spawned in parallel to handle individual PR comment replies. It's optimized for fast execution using the Haiku model and only has access to the tools needed for the specific task.
+
+## Input Parameters
+
+The prompt should provide:
+- `pr_number`: The PR number (integer)
+- `comment_id`: The review comment ID to reply to (integer)
+- `reply_body`: The text of the reply
+- `owner` (optional): Repository owner
+- `repo` (optional): Repository name
+
+## Behavior
+
+1. Extract the parameters from the prompt
+2. Execute the `/gh-pr-comment-reply` slash command with the provided parameters
+3. Report success or failure back to the parent agent
+
+## Example Usage
+
+From a parent agent or skill:
+
+```
+Task(
+  subagent_type="do-gh-pr-comment-reply",
+  description="Reply to PR comment",
+  prompt="""
+    Reply to PR review comment with the following details:
+    - PR number: 300
+    - Comment ID: 2565891355
+    - Reply body: "Fixed in commit abc123"
+  """,
+  model="haiku"
+)
+```
+
+## Success Criteria
+
+The subagent should:
+- Successfully parse the input parameters
+- Execute the slash command correctly
+- Report whether the reply was posted successfully
+- Include the GitHub API response in case of errors
+
+## Error Handling
+
+If the GitHub API call fails, the subagent should:
+1. Include the full error message in its report
+2. Suggest possible causes (invalid PR/comment ID, permissions, etc.)
+3. Mark the task as failed with clear reasoning
+
+This allows the parent agent to track which comments succeeded and which failed.

--- a/.claude/commands/gh-pr-comment-reply.md
+++ b/.claude/commands/gh-pr-comment-reply.md
@@ -1,0 +1,93 @@
+---
+description: Reply to a single GitHub PR review comment using the GitHub API
+---
+
+# Reply to GitHub PR Review Comment
+
+Reply to a single PR review comment using the GitHub API.
+
+## Arguments
+
+Arguments are passed via `$ARGUMENTS` in the format:
+```
+<pr_number> <comment_id> <body> [owner] [repo]
+```
+
+**Required:**
+- `pr_number`: The PR number (integer)
+- `comment_id`: The review comment ID to reply to (integer)
+- `body`: The reply text (string, may contain spaces)
+
+**Optional:**
+- `owner`: Repository owner (defaults to current repo owner)
+- `repo`: Repository name (defaults to current repo name)
+
+## Example Usage
+
+```bash
+# Reply to comment 2565891355 on PR #300
+/gh-pr-comment-reply 300 2565891355 "Fixed in commit abc123"
+
+# With explicit owner/repo
+/gh-pr-comment-reply 300 2565891355 "Fixed" owner repo
+```
+
+## Implementation
+
+Parse the arguments from `$ARGUMENTS`:
+
+```text
+$ARGUMENTS
+```
+
+**Step 1:** Parse arguments
+
+Extract:
+1. First argument: `pr_number`
+2. Second argument: `comment_id`
+3. Remaining arguments (may contain spaces): `body`
+
+If owner/repo are not provided, detect from current repository:
+```bash
+gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}'
+```
+
+**Step 2:** Execute the GitHub API call
+
+Use the `gh api` command to reply to the PR comment:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+  -f body="{body}" \
+  -F in_reply_to={comment_id}
+```
+
+**Important:**
+- The endpoint is: `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments`
+- Parameters:
+  - `body` (string, required): The reply text
+  - `in_reply_to` (integer, required): The comment ID to reply to
+- Use `-f` for string parameters (`body`)
+- Use `-F` for integer parameters (`in_reply_to`)
+
+**Step 3:** Report success or failure
+
+On success, output:
+```
+Successfully replied to comment {comment_id} on PR #{pr_number}
+```
+
+On failure, output the error message and suggest checking:
+- The PR number exists
+- The comment ID is valid
+- You have write access to the repository
+- The GitHub API authentication is working
+
+## Error Handling
+
+Common errors:
+- **404 Not Found**: PR or comment doesn't exist, or no repository access
+- **422 Unprocessable Entity**: Invalid parameters (e.g., wrong comment ID format)
+- **403 Forbidden**: No write access to repository
+
+For any error, display the full GitHub API response to help with debugging.

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: resolve-pr-comments
+description: Orchestrate replying to multiple GitHub PR review comments in parallel. Use when the user wants to reply to multiple PR review comments or resolve all unresolved comments on a PR.
+---
+
+# Resolve PR Comments
+
+Orchestrate replying to multiple GitHub PR review comments in parallel using the `do-gh-pr-comment-reply` subagent.
+
+## Overview
+
+This skill automates the process of replying to multiple PR review comments by:
+1. Fetching all review comments from a PR
+2. Filtering for unresolved or unanswered comments (optional)
+3. Spawning parallel subagents to handle each reply
+4. Collecting and reporting results
+
+## When to Use This Skill
+
+**Use this skill when:**
+- User wants to reply to multiple PR review comments at once
+- User asks to "resolve all comments" on a PR
+- User wants to batch-reply with similar messages (e.g., "Fixed")
+- User needs to mark multiple comments as addressed
+
+**Example user requests:**
+- "Reply to all unresolved comments on PR #300"
+- "Mark all review comments as fixed"
+- "Reply to comments 123, 456, and 789 on this PR"
+- "Resolve all pending review feedback"
+
+## Prerequisites
+
+**Before using this skill:**
+1. Ensure the `gh` CLI is authenticated with proper permissions
+2. Verify the repository and PR exist
+3. Have the reply text prepared (or a strategy for generating replies)
+
+**Permissions required:**
+- Read access to PR comments
+- Write access to post comment replies
+
+## Workflow
+
+### Step 1: Identify the PR
+
+Determine which PR to work with:
+- If user provides PR number, use that
+- If in a PR context (e.g., PR comment in GitHub Actions), extract from context
+- Otherwise, ask the user for the PR number
+
+### Step 2: Fetch PR Review Comments
+
+Use the GitHub API to fetch all review comments:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+  --jq '.[] | {id: .id, body: .body, user: .user.login, in_reply_to_id: .in_reply_to_id}'
+```
+
+**What this returns:**
+- `id`: Comment ID (needed for replying)
+- `body`: Comment text
+- `user`: Who posted the comment
+- `in_reply_to_id`: null if top-level comment, otherwise ID of parent comment
+
+### Step 3: Filter Comments (Optional)
+
+Depending on user requirements, filter the comments:
+
+**Unresolved comments** (no replies yet):
+- Filter where `in_reply_to_id` is null
+- Check if there are any child comments (comments with `in_reply_to_id` matching this comment's `id`)
+
+**Specific comments:**
+- If user provides comment IDs, only process those
+
+**All comments:**
+- Process every comment in the PR
+
+### Step 4: Prepare Reply Content
+
+Determine what to reply with:
+- **User-provided text**: If user specifies reply text, use it for all comments
+- **Per-comment text**: If user provides mapping of comment → reply text
+- **Generated text**: Generate appropriate replies based on comment content
+- **Interactive**: Ask user for reply text for each comment (not recommended for many comments)
+
+### Step 5: Spawn Parallel Subagents
+
+For each comment to reply to, spawn a `do-gh-pr-comment-reply` subagent:
+
+**Important:** Use a SINGLE message with MULTIPLE Task tool calls to spawn agents in parallel:
+
+```
+# Example pseudo-code structure
+# Send ONE message with multiple tool uses:
+
+Task(
+  subagent_type="do-gh-pr-comment-reply",
+  description="Reply to comment 2565891355",
+  prompt="Reply to PR #300 comment 2565891355 with: 'Fixed in commit abc123'",
+  model="haiku"
+)
+
+Task(
+  subagent_type="do-gh-pr-comment-reply",
+  description="Reply to comment 2565891356",
+  prompt="Reply to PR #300 comment 2565891356 with: 'Fixed in commit abc123'",
+  model="haiku"
+)
+
+# ... more Task calls in the same message
+```
+
+**Key points:**
+- All Task calls must be in a SINGLE message for parallel execution
+- Each subagent handles one comment reply independently
+- Use Haiku model for cost efficiency and speed
+- Provide clear, complete parameters in each prompt
+
+### Step 6: Collect Results
+
+After all subagents complete:
+- Parse each subagent's response
+- Count successes and failures
+- Identify which comments failed (if any)
+- Provide summary to user
+
+### Step 7: Report to User
+
+Provide a comprehensive report:
+```
+Replied to 8/10 comments on PR #300:
+
+✅ Succeeded (8):
+  - Comment 2565891355: "Fixed in commit abc123"
+  - Comment 2565891356: "Fixed in commit abc123"
+  - ... (list all successful replies)
+
+❌ Failed (2):
+  - Comment 2565891999: Error 404 - Comment not found
+  - Comment 2565892000: Error 403 - Permission denied
+
+Summary: Successfully replied to 8 out of 10 comments.
+```
+
+## Example Usage Scenarios
+
+### Scenario 1: Resolve All Unresolved Comments
+
+**User request:** "Reply to all unresolved comments on PR #300 with 'Fixed'"
+
+**Workflow:**
+1. Fetch all comments from PR #300
+2. Filter for comments with no replies (in_reply_to_id is null AND no child comments)
+3. For each unresolved comment, spawn subagent to reply with "Fixed"
+4. Report results
+
+### Scenario 2: Reply to Specific Comments
+
+**User request:** "Reply to comments 123, 456, and 789 on PR #300 with 'Addressed'"
+
+**Workflow:**
+1. No need to fetch all comments (user provided specific IDs)
+2. For each comment ID (123, 456, 789), spawn subagent to reply with "Addressed"
+3. Report results
+
+### Scenario 3: Custom Replies Per Comment
+
+**User request:** "Reply to PR #300 comments with these responses:
+- Comment 123: 'Fixed in v2.0'
+- Comment 456: 'This is working as intended'
+- Comment 789: 'Good catch, resolved'"
+
+**Workflow:**
+1. Parse user's comment → reply mapping
+2. For each comment, spawn subagent with the specific reply text
+3. Report results
+
+### Scenario 4: Context-Aware Replies
+
+**User request:** "Read all unresolved comments on PR #300 and reply with appropriate responses"
+
+**Workflow:**
+1. Fetch all unresolved comments
+2. For each comment, analyze the content
+3. Generate appropriate reply based on comment context
+4. Spawn subagents with generated replies
+5. Report results
+
+## Best Practices
+
+### Batching
+
+**Optimal batch sizes:**
+- Small PRs (< 10 comments): Process all at once
+- Medium PRs (10-50 comments): Process all, but use Haiku model for speed
+- Large PRs (> 50 comments): Consider asking user which comments to prioritize
+
+### Error Handling
+
+**Graceful degradation:**
+- If some replies fail, still report successes
+- Provide actionable error messages for failures
+- Offer to retry failed comments
+
+**Common errors:**
+- 404: Comment or PR doesn't exist → Verify comment ID
+- 403: Permission denied → Check repository access
+- 422: Invalid parameters → Verify comment ID format
+
+### Rate Limiting
+
+**GitHub API rate limits:**
+- GitHub API has rate limits (typically 5000 requests/hour for authenticated users)
+- Each reply is one API request
+- For very large batches (> 100 comments), consider warning user about rate limits
+
+### User Confirmation
+
+**Before mass-replying:**
+- Show user which comments will be replied to
+- Show the reply text that will be used
+- Ask for confirmation before proceeding
+
+**Example confirmation:**
+```
+About to reply to 15 unresolved comments on PR #300 with: "Fixed in commit abc123"
+
+Comments to reply to:
+  1. Comment 2565891355: "This function doesn't handle null values"
+  2. Comment 2565891356: "Missing error handling here"
+  ... (list first 5, then "and 10 more")
+
+Proceed? (yes/no)
+```
+
+## Integration with Other Tools
+
+### With GitHub CLI (`gh`)
+
+This skill heavily uses `gh` CLI:
+- `gh api`: For fetching and posting comments
+- `gh pr view`: For PR context
+- `gh repo view`: For repository information
+
+### With SlashCommands
+
+This skill orchestrates the `/gh-pr-comment-reply` slash command via subagents.
+
+### With Other Skills
+
+**Combine with:**
+- `github-issue-breakdown`: For managing PR-related issues
+- `gh-sub-issue`: For tracking comment resolution as sub-tasks
+- `update-github-issue-project-status`: For updating project boards after resolving comments
+
+## Troubleshooting
+
+### Subagents Not Spawning in Parallel
+
+**Cause:** Multiple messages sent instead of one message with multiple Task calls
+
+**Solution:** Ensure all Task tool calls are in a SINGLE response message
+
+### GitHub API Authentication Errors
+
+**Cause:** `gh` CLI not authenticated or lacks permissions
+
+**Solution:**
+```bash
+# Check authentication
+gh auth status
+
+# Re-authenticate with required scopes
+gh auth refresh -s repo
+```
+
+### Comment IDs Not Found
+
+**Cause:** Using wrong endpoint or stale comment IDs
+
+**Solution:**
+- Fetch fresh comment list from GitHub API
+- Verify PR number is correct
+- Check that comments haven't been deleted
+
+### Permission Denied Errors
+
+**Cause:** No write access to repository
+
+**Solution:**
+- Verify repository access: `gh repo view`
+- Check if PR is from a fork (forks have different permissions)
+- Ensure authenticated user has write access
+
+## Environment Requirements
+
+**Prerequisites:**
+- `gh` CLI installed and authenticated
+- Write access to repository
+- PR must exist and be accessible
+
+**Verification:**
+```bash
+# Check gh CLI
+gh --version
+
+# Check authentication
+gh auth status
+
+# Test API access
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --jq 'length'
+```
+
+## Command Reference
+
+### Fetch All PR Comments
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments
+```
+
+Returns array of comment objects.
+
+### Fetch Specific Comment
+
+```bash
+gh api repos/{owner}/{repo}/pulls/comments/{comment_id}
+```
+
+Returns single comment object.
+
+### Post Reply to Comment
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+  -f body="Reply text" \
+  -F in_reply_to={comment_id}
+```
+
+Returns the created comment object.
+
+### Get Comment Thread
+
+To find all replies to a comment:
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+  --jq '.[] | select(.in_reply_to_id == COMMENT_ID)'
+```
+
+## See Also
+
+- **gh-pr-comment-reply** - Slash command for single comment replies
+- **do-gh-pr-comment-reply** - Subagent for single comment replies
+- **GitHub API Documentation** - https://docs.github.com/rest/pulls/comments
+- **gh CLI Documentation** - https://cli.github.com/manual/


### PR DESCRIPTION
## Summary

Implements a complete system for replying to GitHub PR review comments in parallel, consisting of three integrated components as specified in #302.

## Changes

### 1. Slash Command: `/gh-pr-comment-reply`

**File:** `.claude/commands/gh-pr-comment-reply.md`

**Purpose:** Reply to a single PR review comment using the GitHub API

**Arguments:**
- `pr_number` (required): The PR number
- `comment_id` (required): The review comment ID to reply to
- `body` (required): The reply text
- `owner` (optional): Repository owner (defaults to current repo)
- `repo` (optional): Repository name (defaults to current repo)

**Implementation:** Uses `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments` with `body` and `in_reply_to` parameters.

### 2. Subagent: `do-gh-pr-comment-reply`

**File:** `.claude/agents/do-gh-pr-comment-reply.md`

**Purpose:** A focused subagent that replies to a single PR comment

**Configuration:**
- Model: `haiku` (for speed and cost efficiency)
- Tools: `Bash`, `SlashCommand`

**Behavior:** Receives comment details, executes the slash command, reports success/failure

### 3. Skill: `resolve-pr-comments`

**File:** `.claude/skills/resolve-pr-comments/SKILL.md`

**Purpose:** Orchestrate replying to multiple PR comments in parallel

**Workflow:**
1. Fetch PR review comments via GitHub API
2. Filter for unresolved/unanswered comments (optional)
3. Spawn `do-gh-pr-comment-reply` subagents in parallel using Task tool
4. Collect and report results

**When to use:** When user wants to reply to multiple PR review comments or resolve all unresolved comments on a PR.

### 4. Additional Changes

- Created `.claude/agents/` directory for subagent definitions
- Added permissions to `.claude/settings.local.json` (gitignored, not committed):
  - `"Bash(gh api repos/*/pulls/*/comments:*)"`

## Testing

Manual testing requires:
1. An active PR with review comments
2. GitHub CLI authenticated with write access
3. Valid comment IDs to reply to

**Example usage:**
```bash
# Reply to a single comment
/gh-pr-comment-reply 300 2565891355 "Fixed in commit abc123"

# Use the skill for multiple comments
"Reply to all unresolved comments on PR #300 with 'Fixed'"
```

## Integration Points

**With existing skills:**
- Complements `github-issue-breakdown` for PR-related task management
- Works with `gh-sub-issue` for tracking comment resolution
- Can integrate with `update-github-issue-project-status` for project board updates

**With GitHub API:**
- Uses POST `/repos/{owner}/{repo}/pulls/{pull_number}/comments`
- Requires `body` (string) and `in_reply_to` (integer) parameters
- Respects GitHub API rate limits

## Architecture Decisions

1. **Haiku Model for Subagents**: Chosen for speed and cost efficiency since comment replies are straightforward tasks

2. **Parallel Execution**: Skill uses single message with multiple Task calls to spawn subagents in parallel, maximizing throughput

3. **Separation of Concerns**:
   - Slash command: Low-level API interaction
   - Subagent: Single comment handling
   - Skill: Orchestration and batch processing

4. **Error Handling**: Each layer reports detailed errors to enable graceful degradation

## Related Issues

Fixes #302

## Test Plan

- [x] Created slash command with proper arguments and documentation
- [x] Created subagent with correct YAML frontmatter and behavior specification
- [x] Created skill with comprehensive workflow and usage examples
- [x] Added necessary permissions (gitignored settings.local.json)
- [x] Verified .claude/agents/ directory created
- [x] Confirmed all files follow project conventions
- [ ] Manual testing with live PR (requires active PR with comments)

## Documentation

All components include:
- Clear purpose and when-to-use guidelines
- Detailed usage examples
- Error handling instructions
- Integration points with other tools
- Troubleshooting sections

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)