### PR TITLE
✨ feat(ci): add devcontainer feature publish staleness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,47 @@ jobs:
           name: langstar-macos
           path: target/release/langstar
 
+  # Check if devcontainer features need republishing
+  # This job warns but does NOT fail - there may be legitimate reasons to delay publishing
+  # (e.g., waiting for a CLI release first)
+  check-feature-publish-status:
+    name: Check Feature Publish Status
+    runs-on: ubuntu-latest
+    # Only run on PRs to provide visibility during review
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history to compare commits
+
+      - name: Check if features need republishing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get last successful release-features.yaml run commit
+          LAST_PUBLISH=$(gh run list --workflow=release-features.yaml --status=success --json headSha --jq '.[0].headSha' 2>/dev/null || echo "")
+
+          if [ -z "$LAST_PUBLISH" ]; then
+            echo "::notice::No previous feature publish found"
+            exit 0
+          fi
+
+          # Check if feature files changed since last publish
+          CHANGED=$(git diff --name-only "$LAST_PUBLISH" HEAD -- .devcontainer/features/ 2>/dev/null || echo "")
+
+          if [ -n "$CHANGED" ]; then
+            echo "::warning title=Devcontainer Features Need Republishing::Feature files have changed since last publish. After merging, run: gh workflow run release-features.yaml"
+            echo ""
+            echo "Changed files since last publish ($LAST_PUBLISH):"
+            echo "$CHANGED"
+            echo ""
+            echo "To republish after merge:"
+            echo "  gh workflow run release-features.yaml"
+          else
+            echo "✓ Devcontainer features are up to date with published version"
+          fi
+
   # ⚠️ CRITICAL: DO NOT REMOVE THIS JOB
   # This job aggregates all CI results into a single "All Jobs" check.
   # Branch protection requires this check - removing it will block ALL merges to main.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -166,6 +166,35 @@ jobs:
           # --unreleased flag includes commits since last tag
           git-cliff --tag "v$NEW_VERSION" --unreleased --prepend CHANGELOG.md
 
+      - name: Check devcontainer feature status
+        if: steps.check_bump.outputs.skip != 'true'
+        id: feature_status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Get last successful release-features.yaml run commit
+          LAST_PUBLISH=$(gh run list --workflow=release-features.yaml --status=success --json headSha --jq '.[0].headSha' 2>/dev/null || echo "")
+
+          if [ -n "$LAST_PUBLISH" ]; then
+            # Check if feature files changed since then
+            CHANGED_FILES=$(git diff --name-only "$LAST_PUBLISH" HEAD -- .devcontainer/features/ 2>/dev/null || echo "")
+
+            if [ -n "$CHANGED_FILES" ]; then
+              echo "needs_publish=true" >> $GITHUB_OUTPUT
+              echo "::warning::Devcontainer features have changed since last publish!"
+              echo "Changed files:"
+              echo "$CHANGED_FILES"
+            else
+              echo "needs_publish=false" >> $GITHUB_OUTPUT
+              echo "✓ Devcontainer features are up to date with published version"
+            fi
+          else
+            echo "needs_publish=unknown" >> $GITHUB_OUTPUT
+            echo "::notice::No previous feature publish found - cannot determine if republish is needed"
+          fi
+
       - name: Create Pull Request
         if: steps.check_bump.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@v5
@@ -196,6 +225,7 @@ jobs:
             - [ ] Verify version numbers in all Cargo.toml files
             - [ ] Ensure CI passes
             - [ ] Test release artifacts build correctly
+            ${{ steps.feature_status.outputs.needs_publish == 'true' && '- [ ] ⚠️ **Republish devcontainer features** - files changed since last publish. After merge, run: `gh workflow run release-features.yaml`' || '' }}
 
             ---
 


### PR DESCRIPTION
Fixes #317

## Summary

Adds CI safeguards to warn when devcontainer feature files have changed since the last publish to GHCR. This prevents bugs from being fixed in source but never republished (like the issue described in #313).

## Changes

### `prepare-release.yml`
- Adds a new "Check devcontainer feature status" step that:
  - Gets the last successful `release-features.yaml` run commit
  - Compares feature files between that commit and HEAD
  - Outputs `needs_publish=true` if files have changed
- Updates PR body template to include conditional checklist item when republish is needed

### `ci.yml`
- Adds new `check-feature-publish-status` job that:
  - Runs only on PRs (for visibility during review)
  - Warns (does NOT fail) when feature files are stale vs published version
  - Shows changed files and republish command in the warning

## Design Decisions

- **Warning only, not failure**: Per issue requirements, there may be legitimate reasons to delay publishing (e.g., waiting for a CLI release first)
- **Not added to `all-jobs`**: Since this is advisory only, it doesn't block merges
- **PR-only for CI check**: The CI job only runs on PRs where it provides value during review

## Test Plan

- [ ] Create a PR that modifies `.devcontainer/features/` files
- [ ] Verify the "Check Feature Publish Status" check appears and warns
- [ ] Verify the warning doesn't block merging
- [ ] Trigger prepare-release workflow and verify checklist item appears when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)