### PR TITLE
✨ feat(runs): add relative time filters and sensible defaults

### DIFF
--- a/cli/src/commands/runs.rs
+++ b/cli/src/commands/runs.rs
@@ -97,7 +97,10 @@ pub struct QueryArgs {
     #[arg(long)]
     pub since: Option<String>,
 
-    /// Filter runs before this time (ISO 8601 format)
+    /// Filter runs before this time (ISO 8601 format only)
+    ///
+    /// Unlike --since, --until only accepts ISO 8601 timestamps.
+    /// This is intentional: "until 1h ago" is semantically confusing.
     ///
     /// Example: --until 2024-01-31T23:59:59Z
     #[arg(long)]
@@ -984,5 +987,135 @@ mod tests {
         assert_eq!(calculate_per_page_limit(101), 100);
         assert_eq!(calculate_per_page_limit(500), 100);
         assert_eq!(calculate_per_page_limit(1000), 100);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // resolve_time_filters tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// Helper to create a minimal QueryArgs for testing
+    fn create_test_query_args() -> QueryArgs {
+        QueryArgs {
+            projects: vec![],
+            filter: None,
+            trace_filter: None,
+            tree_filter: None,
+            is_root: false,
+            tags: vec![],
+            metadata: vec![],
+            run_type: None,
+            status: None,
+            errors_only: false,
+            since: None,
+            until: None,
+            preset: None,
+            no_time_filter: false,
+            limit: 100,
+            order: OrderArg::Desc,
+            output: RunsOutputFormat::Table,
+            select: None,
+            organization_id: None,
+            workspace_id: None,
+        }
+    }
+
+    #[test]
+    fn test_resolve_time_filters_default_7_days() {
+        let args = create_test_query_args();
+        let formatter = crate::output::OutputFormatter::new(crate::output::OutputFormat::Table);
+        let (start, end, desc) = RunsCommands::resolve_time_filters(&args, &formatter);
+
+        assert!(start.is_some(), "Default should have start time");
+        assert!(end.is_none(), "Default should have no end time");
+        assert_eq!(desc, "last 7 days (default)");
+
+        // Verify it's approximately 7 days ago
+        let now = chrono::Utc::now();
+        let diff = now - start.unwrap();
+        assert!(diff.num_days() >= 6 && diff.num_days() <= 7);
+    }
+
+    #[test]
+    fn test_resolve_time_filters_no_time_filter() {
+        let mut args = create_test_query_args();
+        args.no_time_filter = true;
+        let formatter = crate::output::OutputFormatter::new(crate::output::OutputFormat::Table);
+        let (start, end, desc) = RunsCommands::resolve_time_filters(&args, &formatter);
+
+        assert!(start.is_none(), "--no-time-filter should have no start");
+        assert!(end.is_none(), "--no-time-filter should have no end");
+        assert_eq!(desc, "none (--no-time-filter)");
+    }
+
+    #[test]
+    fn test_resolve_time_filters_preset() {
+        let mut args = create_test_query_args();
+        args.preset = Some(crate::time::TimePreset::ThreeHours);
+        let formatter = crate::output::OutputFormatter::new(crate::output::OutputFormat::Table);
+        let (start, end, desc) = RunsCommands::resolve_time_filters(&args, &formatter);
+
+        assert!(start.is_some(), "Preset should have start time");
+        assert!(end.is_none(), "Preset should have no end time");
+        assert_eq!(desc, "Last 3 hours (preset)");
+
+        // Verify it's approximately 3 hours ago
+        let now = chrono::Utc::now();
+        let diff = now - start.unwrap();
+        assert!(diff.num_hours() >= 2 && diff.num_hours() <= 3);
+    }
+
+    #[test]
+    fn test_resolve_time_filters_since_relative() {
+        let mut args = create_test_query_args();
+        args.since = Some("2h".to_string());
+        let formatter = crate::output::OutputFormatter::new(crate::output::OutputFormat::Table);
+        let (start, end, desc) = RunsCommands::resolve_time_filters(&args, &formatter);
+
+        assert!(start.is_some(), "Relative --since should have start time");
+        assert!(end.is_none(), "Relative --since should have no end time");
+        assert_eq!(desc, "last 2h (relative)");
+
+        // Verify it's approximately 2 hours ago
+        let now = chrono::Utc::now();
+        let diff = now - start.unwrap();
+        assert!(diff.num_hours() >= 1 && diff.num_hours() <= 2);
+    }
+
+    #[test]
+    fn test_resolve_time_filters_since_iso8601() {
+        let mut args = create_test_query_args();
+        args.since = Some("2024-06-15T14:30:00Z".to_string());
+        let formatter = crate::output::OutputFormatter::new(crate::output::OutputFormat::Table);
+        let (start, end, desc) = RunsCommands::resolve_time_filters(&args, &formatter);
+
+        assert!(start.is_some(), "ISO 8601 --since should have start time");
+        assert!(end.is_none(), "ISO 8601 --since should have no end time");
+        assert!(desc.contains("ISO 8601"));
+    }
+
+    #[test]
+    fn test_resolve_time_filters_until_iso8601() {
+        let mut args = create_test_query_args();
+        args.until = Some("2024-06-15T14:30:00Z".to_string());
+        let formatter = crate::output::OutputFormatter::new(crate::output::OutputFormat::Table);
+        let (start, end, desc) = RunsCommands::resolve_time_filters(&args, &formatter);
+
+        // Default start still applies, but end should be set
+        assert!(start.is_some(), "Should still have default start time");
+        assert!(end.is_some(), "--until should set end time");
+        assert_eq!(desc, "last 7 days (default)");
+    }
+
+    #[test]
+    fn test_resolve_time_filters_precedence_since_over_preset() {
+        let mut args = create_test_query_args();
+        args.since = Some("1h".to_string());
+        args.preset = Some(crate::time::TimePreset::SevenDays);
+        let formatter = crate::output::OutputFormatter::new(crate::output::OutputFormat::Table);
+        let (start, _end, desc) = RunsCommands::resolve_time_filters(&args, &formatter);
+
+        // --since should take precedence over --preset
+        assert!(start.is_some());
+        assert_eq!(desc, "last 1h (relative)");
     }
 }

--- a/cli/src/time.rs
+++ b/cli/src/time.rs
@@ -73,12 +73,17 @@ pub fn parse_relative_duration(s: &str) -> Result<Duration, String> {
     }
 }
 
+/// Valid unit strings for relative durations.
+const VALID_DURATION_UNITS: &[&str] = &[
+    "m", "min", "mins", "minute", "minutes", "h", "hr", "hrs", "hour", "hours", "d", "day", "days",
+    "w", "wk", "wks", "week", "weeks",
+];
+
 /// Check if a string looks like a relative duration (e.g., "15m", "1h").
 ///
 /// This is used to distinguish between ISO 8601 timestamps and relative durations.
 /// A relative duration is a simple format like "15m", "1h", "7d", "2w" - it starts
-/// with digits and ends with a valid unit letter, and does NOT contain characters
-/// that indicate ISO 8601 format (like '-', ':', or 'T').
+/// with digits followed by exactly a valid unit string.
 pub fn is_relative_duration(s: &str) -> bool {
     let s = s.trim();
     if s.is_empty() {
@@ -90,33 +95,22 @@ pub fn is_relative_duration(s: &str) -> bool {
         return false;
     }
 
-    // Relative durations start with digits
-    let starts_with_digit = s.chars().next().is_some_and(|c| c.is_ascii_digit());
-    if !starts_with_digit {
+    // Find the split point between number and unit
+    let split_idx = match s.find(|c: char| !c.is_ascii_digit()) {
+        Some(idx) => idx,
+        None => return false, // No unit found (e.g., "123")
+    };
+
+    // Must start with at least one digit
+    if split_idx == 0 {
         return false;
     }
 
-    // Relative durations end with a valid unit letter (m, h, d, w, or longer variants)
-    // We check for common endings, not just any letter (to avoid false positives like 'Z')
-    let s_lower = s.to_lowercase();
-    s_lower.ends_with('m')
-        || s_lower.ends_with('h')
-        || s_lower.ends_with('d')
-        || s_lower.ends_with('w')
-        || s_lower.ends_with("min")
-        || s_lower.ends_with("mins")
-        || s_lower.ends_with("minute")
-        || s_lower.ends_with("minutes")
-        || s_lower.ends_with("hr")
-        || s_lower.ends_with("hrs")
-        || s_lower.ends_with("hour")
-        || s_lower.ends_with("hours")
-        || s_lower.ends_with("day")
-        || s_lower.ends_with("days")
-        || s_lower.ends_with("wk")
-        || s_lower.ends_with("wks")
-        || s_lower.ends_with("week")
-        || s_lower.ends_with("weeks")
+    let (_num_str, unit) = s.split_at(split_idx);
+    let unit_lower = unit.to_lowercase();
+
+    // Check if unit exactly matches one of the valid units
+    VALID_DURATION_UNITS.contains(&unit_lower.as_str())
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes #327

## Summary

- Add relative duration parsing (`15m`, `1h`, `7d`, `2w`) for `--since` flag
- Add `--preset` flag with common time windows (`1h`, `3h`, `6h`, `12h`, `1d`, `2d`, `7d`, `14d`)
- Change default to last 7 days (matches LangSmith UI)
- Add `--no-time-filter` flag to disable default time filtering
- Implement precedence: `--since/--until` > `--since` (relative) > `--preset` > default

## Usage Examples

```bash
# Default: last 7 days (matches LangSmith UI)
langstar runs query

# Relative durations
langstar runs query --since 15m     # Last 15 minutes
langstar runs query --since 1h      # Last 1 hour
langstar runs query --since 2w      # Last 2 weeks

# Presets
langstar runs query --preset 3h     # Last 3 hours
langstar runs query --preset 14d    # Last 14 days

# ISO 8601 (unchanged)
langstar runs query --since 2024-01-01T00:00:00Z

# No time filter (query all runs)
langstar runs query --no-time-filter
```

## Test plan

- [x] Unit tests for `parse_relative_duration()` - minutes, hours, days, weeks
- [x] Unit tests for `is_relative_duration()` - distinguishes ISO 8601 from relative
- [x] Unit tests for `TimePreset` - all presets, default, descriptions
- [x] All existing runs command tests pass
- [x] `cargo fmt`, `cargo check`, `cargo clippy`, `cargo test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)