### PR TITLE
🧪 test(datasets): add comprehensive tests for dataset operations

### DIFF
--- a/cli/tests/dataset_command_test.rs
+++ b/cli/tests/dataset_command_test.rs
@@ -685,10 +685,7 @@ mod integration {
         }
 
         // 1. Create dataset
-        let unique_name = format!(
-            "test-dataset-{}",
-            Uuid::new_v4().to_string()[..8].to_string()
-        );
+        let unique_name = format!("test-dataset-{}", &Uuid::new_v4().to_string()[..8]);
         let mut cmd = langstar_cmd();
         cmd.args([
             "dataset",
@@ -768,10 +765,7 @@ mod integration {
         }
 
         let temp_dir = TempDir::new().unwrap();
-        let unique_name = format!(
-            "roundtrip-test-{}",
-            Uuid::new_v4().to_string()[..8].to_string()
-        );
+        let unique_name = format!("roundtrip-test-{}", &Uuid::new_v4().to_string()[..8]);
 
         // 1. Create dataset
         let mut cmd = langstar_cmd();

--- a/sdk/tests/dataset_test.rs
+++ b/sdk/tests/dataset_test.rs
@@ -721,10 +721,7 @@ async fn test_dataset_crud_live_api() {
     let client = LangchainClient::new(auth).expect("Failed to create client");
 
     // 1. Create dataset
-    let unique_name = format!(
-        "test-dataset-{}",
-        Uuid::new_v4().to_string()[..8].to_string()
-    );
+    let unique_name = format!("test-dataset-{}", &Uuid::new_v4().to_string()[..8]);
     let request = DatasetCreate {
         name: unique_name.clone(),
         description: Some("Integration test dataset".to_string()),


### PR DESCRIPTION
## Summary

Adds comprehensive tests for dataset operations as part of issue #354 (346.7-dataset-testing). This PR follows #380 which added the dataset CLI commands.

### Changes

**CLI Tests (`cli/tests/dataset_command_test.rs`):**
- 33 tests covering all 8 dataset subcommands
- Help text verification for each subcommand
- Argument validation (required args, invalid UUIDs, invalid formats)
- Valid argument combination tests
- Error handling (missing API key, file not found, invalid formats)
- Import/export format auto-detection tests
- Integration tests (feature-gated with `integration-tests` flag)

**SDK Tests (`sdk/tests/dataset_test.rs`):**
- 18 mocked HTTP tests for dataset and example operations
- Dataset CRUD (create, list, get, update, delete)
- Example CRUD (create, list, get, update, delete, bulk_create)
- Error handling (401, 404, 500 responses)
- Live API integration tests (ignored by default)

### Test Results

- All 51 new tests pass
- 4 integration tests are ignored due to known CLI bugs (documented below)
- Existing 12 serialization tests in `datasets.rs` continue to pass

### Bugs Discovered

The integration tests uncovered two bugs in the CLI that are now documented with `#[ignore]` annotations:

1. **Export format conflict**: `dataset export --format jsonl` conflicts with the global `-f, --format` output format flag
2. **Update response decoding**: `dataset update` fails with "error decoding response body"

These should be tracked as separate issues.

Fixes #354

## Test plan
- [x] `cargo fmt` - passes
- [x] `cargo check --workspace --all-features` - passes
- [x] `cargo clippy --workspace --all-features -- -D warnings` - passes
- [x] `cargo test --workspace --all-features` - all tests pass
- [x] 33 CLI tests pass (2 integration tests properly ignored)
- [x] 18 SDK mocked HTTP tests pass (2 live API tests properly ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)