### PR TITLE
✨ feat(sdk): add feedback CRUD methods for evaluations

### DIFF
--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -1737,8 +1737,7 @@ impl LangchainClient {
     pub async fn delete_feedback(&self, feedback_id: uuid::Uuid) -> Result<()> {
         let path = format!("/api/v1/feedback/{}", feedback_id);
         let request = self.langsmith_delete(&path)?;
-        let _response: serde_json::Value = self.execute(request).await?;
-        Ok(())
+        self.execute_status_only_request(request).await
     }
 }
 


### PR DESCRIPTION
## Summary

Implements evaluation client methods in the SDK as specified in issue #371.

This PR adds complete CRUD operations for the LangSmith feedback API, which is the primary interface for recording evaluation results.

## Changes

### SDK Methods Added (`sdk/src/client.rs`)

1. **`create_feedback()`** - Create evaluation feedback for runs
   - Records evaluation results from heuristic or LLM-as-judge evaluators
   - Supports continuous (numeric), categorical (enum), and freeform (text) feedback types
   
2. **`list_feedback()`** - List feedback with optional run_id filter
   - Query all feedback or filter by specific run
   
3. **`get_feedback()`** - Retrieve specific feedback by ID
   - Fetch individual feedback entries
   
4. **`update_feedback()`** - Update existing feedback entries
   - Modify score, comment, or other feedback fields
   
5. **`delete_feedback()`** - Delete feedback entries
   - Remove unwanted feedback

### Documentation

- All methods include comprehensive rustdoc with:
  - Detailed parameter descriptions
  - Return type documentation
  - Usage examples
  - API endpoint references

### Testing

- ✅ All existing tests pass
- ✅ Cargo check passes
- ✅ Cargo clippy passes with no warnings
- ✅ Cargo fmt applied

## API Endpoints

| Operation | Method | Endpoint |
|-----------|--------|----------|
| Create feedback | POST | `/api/v1/feedback` |
| List feedback | GET | `/api/v1/feedback` |
| Get feedback | GET | `/api/v1/feedback/{feedback_id}` |
| Update feedback | PATCH | `/api/v1/feedback/{feedback_id}` |
| Delete feedback | DELETE | `/api/v1/feedback/{feedback_id}` |

## Related Issues

Fixes #371

## References

- Prior work: #370 (evaluation types)
- Research: `reference/research/347-ls-evals-precedent.md`
- Milestone: ls-evals-basic

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>