### PR TITLE
📚 docs(prompts): validate structured output prompt design against OpenAPI spec

### DIFF
--- a/reference/api-specs/langsmith/FRAGMENTS.md
+++ b/reference/api-specs/langsmith/FRAGMENTS.md
@@ -28,6 +28,8 @@ These fragments are extracted subsets of the full OpenAPI spec, optimized for:
 | `example-schemas.json` | 29K | Example data types | See below | 2025-11-28 |
 | `evals-endpoints.json` | 45K | Evaluation/feedback API endpoints | See below | 2025-11-28 |
 | `evals-schemas.json` | 38K | Evaluation/feedback data types | See below | 2025-11-28 |
+| `prompt-endpoints.json` | 45K | Prompt repository/commit API endpoints | See below | 2025-11-29 |
+| `prompt-schemas.json` | 37K | Prompt/commit/manifest data types | See below | 2025-11-29 |
 
 ## Extraction Commands
 
@@ -81,6 +83,14 @@ jq '.paths | with_entries(select(.key | test("feedback|evaluator"; "i")))' \
 # Evaluation/feedback schemas (all schemas containing "feedback", "evaluator", or "eval")
 jq '.components.schemas | with_entries(select(.key | test("feedback|evaluator|eval"; "i")))' \
   openapi.json > ../../api-specs/langsmith/evals-schemas.json
+
+# Prompt repository and commit endpoints (all /api/v1/repos and /api/v1/commits paths)
+jq '.paths | with_entries(select(.key | test("^/api/v1/(repos|commits)")))' \
+  openapi.json > ../../api-specs/langsmith/prompt-endpoints.json
+
+# Prompt/commit/manifest schemas (all schemas containing "repo", "commit", "prompt", or "manifest")
+jq '.components.schemas | with_entries(select(.key | test("[Rr]epo|[Cc]ommit|[Pp]rompt|[Mm]anifest"; "i")))' \
+  openapi.json > ../../api-specs/langsmith/prompt-schemas.json
 ```
 
 ## Verification
@@ -108,3 +118,4 @@ jq '.paths | keys | map(select(contains("annotation-queue"))) | length' \
   - `../../research/298-openapi-validation.md` - Runs query validation
   - `../../research/334-openapi-validation.md` - Annotation queues validation
   - `../../research/347-openapi-validation.md` - Evaluations/feedback validation
+  - `../../research/402-structured-prompts-openapi-validation.md` - Structured output prompts validation

--- a/reference/api-specs/langsmith/prompt-endpoints.json
+++ b/reference/api-specs/langsmith/prompt-endpoints.json
@@ -1,0 +1,2007 @@
+{
+  "/api/v1/repos": {
+    "get": {
+      "tags": [
+        "repos"
+      ],
+      "summary": "List Repos",
+      "description": "Get all repos.",
+      "operationId": "list_repos_api_v1_repos_get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "with_latest_manifest",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "boolean",
+            "default": false,
+            "title": "With Latest Manifest"
+          }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1,
+            "default": 20,
+            "title": "Limit"
+          }
+        },
+        {
+          "name": "offset",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "title": "Offset"
+          }
+        },
+        {
+          "name": "tenant_handle",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tenant Handle"
+          }
+        },
+        {
+          "name": "tenant_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tenant Id"
+          }
+        },
+        {
+          "name": "query",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Query"
+          }
+        },
+        {
+          "name": "has_commits",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Has Commits"
+          }
+        },
+        {
+          "name": "tags",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          }
+        },
+        {
+          "name": "is_archived",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "enum": [
+                  "true",
+                  "allow",
+                  "false"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Archived"
+          }
+        },
+        {
+          "name": "is_public",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "enum": [
+                  "true",
+                  "false"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Public"
+          }
+        },
+        {
+          "name": "upstream_repo_owner",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upstream Repo Owner"
+          }
+        },
+        {
+          "name": "upstream_repo_handle",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upstream Repo Handle"
+          }
+        },
+        {
+          "name": "tag_value_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Value Id"
+          }
+        },
+        {
+          "name": "sort_field",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "enum": [
+                  "num_likes",
+                  "num_downloads",
+                  "num_views",
+                  "updated_at",
+                  "relevance"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Field"
+          }
+        },
+        {
+          "name": "sort_direction",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "const": "asc",
+                "type": "string"
+              },
+              {
+                "const": "desc",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Direction"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListReposResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "post": {
+      "tags": [
+        "repos"
+      ],
+      "summary": "Create Repo",
+      "description": "Create a repo.",
+      "operationId": "create_repo_api_v1_repos_post",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CreateRepoRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRepoResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/{owner}/{repo}": {
+    "get": {
+      "tags": [
+        "repos"
+      ],
+      "summary": "Get Repo",
+      "description": "Get a repo.",
+      "operationId": "get_repo_api_v1_repos__owner___repo__get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "owner",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Owner"
+          }
+        },
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetRepoResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "patch": {
+      "tags": [
+        "repos"
+      ],
+      "summary": "Update Repo",
+      "description": "Update a repo.",
+      "operationId": "update_repo_api_v1_repos__owner___repo__patch",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "owner",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Owner"
+          }
+        },
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/UpdateRepoRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRepoResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "tags": [
+        "repos"
+      ],
+      "summary": "Delete Repo",
+      "description": "Delete a repo.",
+      "operationId": "delete_repo_api_v1_repos__owner___repo__delete",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "owner",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Owner"
+          }
+        },
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/{owner}/{repo}/fork": {
+    "post": {
+      "tags": [
+        "repos"
+      ],
+      "summary": "Fork Repo",
+      "description": "Fork a repo.",
+      "operationId": "fork_repo_api_v1_repos__owner___repo__fork_post",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "owner",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Owner"
+          }
+        },
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ForkRepoRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetRepoResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/tags": {
+    "get": {
+      "tags": [
+        "repos"
+      ],
+      "summary": "List Repo Tags",
+      "description": "Get all repo tags.",
+      "operationId": "list_repo_tags_api_v1_repos_tags_get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1,
+            "default": 20,
+            "title": "Limit"
+          }
+        },
+        {
+          "name": "offset",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "title": "Offset"
+          }
+        },
+        {
+          "name": "tenant_handle",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tenant Handle"
+          }
+        },
+        {
+          "name": "tenant_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tenant Id"
+          }
+        },
+        {
+          "name": "query",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Query"
+          }
+        },
+        {
+          "name": "has_commits",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Has Commits"
+          }
+        },
+        {
+          "name": "tags",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          }
+        },
+        {
+          "name": "is_archived",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "enum": [
+                  "true",
+                  "allow",
+                  "false"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Archived"
+          }
+        },
+        {
+          "name": "is_public",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "enum": [
+                  "true",
+                  "false"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Public"
+          }
+        },
+        {
+          "name": "upstream_repo_owner",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upstream Repo Owner"
+          }
+        },
+        {
+          "name": "upstream_repo_handle",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upstream Repo Handle"
+          }
+        },
+        {
+          "name": "tag_value_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Value Id"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListTagsResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/optimize-job": {
+    "post": {
+      "tags": [
+        "repos"
+      ],
+      "summary": "Optimize Prompt Job",
+      "description": "Optimize prompt",
+      "operationId": "optimize_prompt_job_api_v1_repos_optimize_job_post",
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/OptimizePromptJobRequest"
+            }
+          }
+        },
+        "required": true
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OptimizePromptResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ]
+    }
+  },
+  "/api/v1/commits/{owner}/{repo}": {
+    "get": {
+      "tags": [
+        "commits"
+      ],
+      "summary": "List Commits",
+      "description": "Get all commits.",
+      "operationId": "list_commits_api_v1_commits__owner___repo__get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "owner",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Owner"
+          }
+        },
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1,
+            "default": 20,
+            "title": "Limit"
+          }
+        },
+        {
+          "name": "offset",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "title": "Offset"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListCommitsResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "post": {
+      "tags": [
+        "commits"
+      ],
+      "summary": "Create Commit",
+      "description": "Upload a repo.",
+      "operationId": "create_commit_api_v1_commits__owner___repo__post",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "owner",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Owner"
+          }
+        },
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CreateRepoCommitRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRepoCommitResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/commits/{owner}/{repo}/{commit}": {
+    "get": {
+      "tags": [
+        "commits"
+      ],
+      "summary": "Get Commit",
+      "description": "Download a repo.",
+      "operationId": "get_commit_api_v1_commits__owner___repo___commit__get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "owner",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Owner"
+          }
+        },
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        },
+        {
+          "name": "commit",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Commit"
+          }
+        },
+        {
+          "name": "get_examples",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "boolean",
+            "default": false,
+            "title": "Get Examples"
+          }
+        },
+        {
+          "name": "is_view",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "boolean",
+            "default": false,
+            "title": "Is View"
+          }
+        },
+        {
+          "name": "include_model",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": false,
+            "title": "Include Model"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitManifestResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/{owner}/{repo}/tags": {
+    "get": {
+      "tags": [
+        "tags"
+      ],
+      "summary": "Get Tags",
+      "operationId": "get_tags_api_v1_repos__owner___repo__tags_get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RepoTag"
+                },
+                "title": "Response Get Tags Api V1 Repos  Owner   Repo  Tags Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "post": {
+      "tags": [
+        "tags"
+      ],
+      "summary": "Create Tag",
+      "operationId": "create_tag_api_v1_repos__owner___repo__tags_post",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RepoTagRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepoTag"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/{owner}/{repo}/tags/{tag_name}": {
+    "get": {
+      "tags": [
+        "tags"
+      ],
+      "summary": "Get Tag",
+      "operationId": "get_tag_api_v1_repos__owner___repo__tags__tag_name__get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        },
+        {
+          "name": "tag_name",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Tag Name"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepoTag"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "patch": {
+      "tags": [
+        "tags"
+      ],
+      "summary": "Update Tag",
+      "operationId": "update_tag_api_v1_repos__owner___repo__tags__tag_name__patch",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        },
+        {
+          "name": "tag_name",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Tag Name"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RepoUpdateTagRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepoTag"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "tags": [
+        "tags"
+      ],
+      "summary": "Delete Tag",
+      "operationId": "delete_tag_api_v1_repos__owner___repo__tags__tag_name__delete",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        },
+        {
+          "name": "tag_name",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Tag Name"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/{owner}/{repo}/optimization-jobs": {
+    "get": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "List Jobs",
+      "description": "List all prompt optimization jobs.",
+      "operationId": "list_jobs_api_v1_repos__owner___repo__optimization_jobs_get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PromptOptimizationJob"
+                },
+                "title": "Response List Jobs Api V1 Repos  Owner   Repo  Optimization Jobs Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "post": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "Create Job",
+      "description": "Create a new prompt optimization job.",
+      "operationId": "create_job_api_v1_repos__owner___repo__optimization_jobs_post",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "repo",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Repo"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PromptOptimizationJobCreate"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptOptimizationJob"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/{owner}/{repo}/optimization-jobs/{job_id}": {
+    "get": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "Get Job",
+      "description": "Get a specific optimization job.",
+      "operationId": "get_job_api_v1_repos__owner___repo__optimization_jobs__job_id__get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "job_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Job Id"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptOptimizationJobWithLogs"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "patch": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "Update Job",
+      "description": "Replace an existing prompt optimization job with a new, modified job.",
+      "operationId": "update_job_api_v1_repos__owner___repo__optimization_jobs__job_id__patch",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "job_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Job Id"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PromptOptimizationJobUpdate"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptOptimizationJob"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "Delete Job",
+      "description": "Delete a prompt optimization job.",
+      "operationId": "delete_job_api_v1_repos__owner___repo__optimization_jobs__job_id__delete",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "job_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Job Id"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/{owner}/{repo}/optimization-jobs/{job_id}/logs": {
+    "get": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "List Job Logs",
+      "description": "List all logs for a specific prompt optimization job.",
+      "operationId": "list_job_logs_api_v1_repos__owner___repo__optimization_jobs__job_id__logs_get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "job_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Job Id"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PromptOptimizationJobLog"
+                },
+                "title": "Response List Job Logs Api V1 Repos  Owner   Repo  Optimization Jobs  Job Id  Logs Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "post": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "Create Log",
+      "description": "Create a new log entry for a prompt optimization job.",
+      "operationId": "create_log_api_v1_repos__owner___repo__optimization_jobs__job_id__logs_post",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "job_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Job Id"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PromptOptimizationJobLogCreate"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptOptimizationJobLog"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/v1/repos/{owner}/{repo}/optimization-jobs/{job_id}/logs/{log_id}": {
+    "get": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "Get Log",
+      "description": "Get a specific prompt optimization job log.",
+      "operationId": "get_log_api_v1_repos__owner___repo__optimization_jobs__job_id__logs__log_id__get",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "log_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Log Id"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptOptimizationJobLog"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "tags": [
+        "optimization-jobs"
+      ],
+      "summary": "Delete Log",
+      "description": "Delete a prompt optimization job log.",
+      "operationId": "delete_log_api_v1_repos__owner___repo__optimization_jobs__job_id__logs__log_id__delete",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "log_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Log Id"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/api-specs/langsmith/prompt-schemas.json
+++ b/reference/api-specs/langsmith/prompt-schemas.json
@@ -1,0 +1,1839 @@
+{
+  "CommitManifestResponse": {
+    "properties": {
+      "commit_hash": {
+        "type": "string",
+        "title": "Commit Hash"
+      },
+      "manifest": {
+        "additionalProperties": true,
+        "type": "object",
+        "title": "Manifest"
+      },
+      "examples": {
+        "anyOf": [
+          {
+            "items": {
+              "$ref": "#/components/schemas/RepoExampleResponse"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Examples"
+      }
+    },
+    "type": "object",
+    "required": [
+      "commit_hash",
+      "manifest"
+    ],
+    "title": "CommitManifestResponse",
+    "description": "Response model for get_commit_manifest."
+  },
+  "CommitWithLookups": {
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Id"
+      },
+      "manifest": {
+        "additionalProperties": true,
+        "type": "object",
+        "title": "Manifest"
+      },
+      "repo_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Repo Id"
+      },
+      "parent_id": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Parent Id"
+      },
+      "commit_hash": {
+        "type": "string",
+        "title": "Commit Hash"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Created At"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Updated At"
+      },
+      "example_run_ids": {
+        "items": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "type": "array",
+        "title": "Example Run Ids"
+      },
+      "num_downloads": {
+        "type": "integer",
+        "title": "Num Downloads"
+      },
+      "num_views": {
+        "type": "integer",
+        "title": "Num Views"
+      },
+      "parent_commit_hash": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Parent Commit Hash"
+      },
+      "full_name": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Full Name"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "manifest",
+      "repo_id",
+      "commit_hash",
+      "created_at",
+      "updated_at",
+      "example_run_ids",
+      "num_downloads",
+      "num_views"
+    ],
+    "title": "CommitWithLookups",
+    "description": "All database fields for commits, plus helpful computed fields and user info\nfor private prompts."
+  },
+  "CreateRepoCommitRequest": {
+    "properties": {
+      "manifest": {
+        "additionalProperties": true,
+        "type": "object",
+        "title": "Manifest"
+      },
+      "parent_commit": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Parent Commit"
+      },
+      "example_run_ids": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Example Run Ids"
+      },
+      "skip_webhooks": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          }
+        ],
+        "title": "Skip Webhooks",
+        "default": false
+      }
+    },
+    "type": "object",
+    "required": [
+      "manifest"
+    ],
+    "title": "CreateRepoCommitRequest"
+  },
+  "CreateRepoCommitResponse": {
+    "properties": {
+      "commit": {
+        "$ref": "#/components/schemas/CommitWithLookups"
+      }
+    },
+    "type": "object",
+    "required": [
+      "commit"
+    ],
+    "title": "CreateRepoCommitResponse"
+  },
+  "CreateRepoRequest": {
+    "properties": {
+      "repo_handle": {
+        "type": "string",
+        "title": "Repo Handle"
+      },
+      "description": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Description"
+      },
+      "readme": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Readme"
+      },
+      "is_public": {
+        "type": "boolean",
+        "title": "Is Public"
+      },
+      "tags": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Tags"
+      }
+    },
+    "type": "object",
+    "required": [
+      "repo_handle",
+      "is_public"
+    ],
+    "title": "CreateRepoRequest",
+    "description": "Fields to create a repo"
+  },
+  "CreateRepoResponse": {
+    "properties": {
+      "repo": {
+        "$ref": "#/components/schemas/RepoWithLookups"
+      }
+    },
+    "type": "object",
+    "required": [
+      "repo"
+    ],
+    "title": "CreateRepoResponse"
+  },
+  "EPromptOptimizationAlgorithm": {
+    "type": "string",
+    "enum": [
+      "promptim",
+      "demo"
+    ],
+    "title": "EPromptOptimizationAlgorithm"
+  },
+  "EPromptOptimizationJobLogType": {
+    "type": "string",
+    "enum": [
+      "info",
+      "result",
+      "error",
+      "link"
+    ],
+    "title": "EPromptOptimizationJobLogType"
+  },
+  "EPromptOptimizationJobStatus": {
+    "type": "string",
+    "enum": [
+      "created",
+      "running",
+      "successful",
+      "failed"
+    ],
+    "title": "EPromptOptimizationJobStatus"
+  },
+  "EPromptWebhookTrigger": {
+    "type": "string",
+    "enum": [
+      "commit",
+      "tag:create",
+      "tag:update"
+    ],
+    "title": "EPromptWebhookTrigger",
+    "description": "Valid trigger types for prompt webhooks."
+  },
+  "ForkRepoRequest": {
+    "properties": {
+      "repo_handle": {
+        "type": "string",
+        "title": "Repo Handle"
+      },
+      "readme": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Readme"
+      },
+      "description": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Description"
+      },
+      "tags": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Tags"
+      },
+      "is_public": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Is Public"
+      }
+    },
+    "type": "object",
+    "required": [
+      "repo_handle"
+    ],
+    "title": "ForkRepoRequest",
+    "description": "Fields to fork a repo"
+  },
+  "GetRepoResponse": {
+    "properties": {
+      "repo": {
+        "$ref": "#/components/schemas/RepoWithLookups"
+      }
+    },
+    "type": "object",
+    "required": [
+      "repo"
+    ],
+    "title": "GetRepoResponse"
+  },
+  "InvokePromptPayload": {
+    "properties": {
+      "messages": {
+        "items": {
+          "prefixItems": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2
+        },
+        "type": "array",
+        "title": "Messages"
+      },
+      "template_format": {
+        "type": "string",
+        "title": "Template Format"
+      },
+      "inputs": {
+        "additionalProperties": true,
+        "type": "object",
+        "title": "Inputs"
+      }
+    },
+    "type": "object",
+    "required": [
+      "messages",
+      "template_format",
+      "inputs"
+    ],
+    "title": "InvokePromptPayload"
+  },
+  "LikeRepoRequest": {
+    "properties": {
+      "like": {
+        "type": "boolean",
+        "title": "Like"
+      }
+    },
+    "type": "object",
+    "required": [
+      "like"
+    ],
+    "title": "LikeRepoRequest"
+  },
+  "LikeRepoResponse": {
+    "properties": {
+      "likes": {
+        "type": "integer",
+        "title": "Likes"
+      }
+    },
+    "type": "object",
+    "required": [
+      "likes"
+    ],
+    "title": "LikeRepoResponse"
+  },
+  "ListCommitsResponse": {
+    "properties": {
+      "commits": {
+        "items": {
+          "$ref": "#/components/schemas/CommitWithLookups"
+        },
+        "type": "array",
+        "title": "Commits"
+      },
+      "total": {
+        "type": "integer",
+        "title": "Total"
+      }
+    },
+    "type": "object",
+    "required": [
+      "commits",
+      "total"
+    ],
+    "title": "ListCommitsResponse"
+  },
+  "ListReposResponse": {
+    "properties": {
+      "repos": {
+        "items": {
+          "$ref": "#/components/schemas/RepoWithLookups"
+        },
+        "type": "array",
+        "title": "Repos"
+      },
+      "total": {
+        "type": "integer",
+        "title": "Total"
+      }
+    },
+    "type": "object",
+    "required": [
+      "repos",
+      "total"
+    ],
+    "title": "ListReposResponse"
+  },
+  "OptimizePromptJobRequest": {
+    "properties": {
+      "algorithm": {
+        "$ref": "#/components/schemas/EPromptOptimizationAlgorithm"
+      },
+      "config": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PromptimConfig"
+          },
+          {
+            "$ref": "#/components/schemas/DemoConfig"
+          }
+        ],
+        "title": "Config"
+      },
+      "prompt_name": {
+        "type": "string",
+        "title": "Prompt Name"
+      }
+    },
+    "type": "object",
+    "required": [
+      "algorithm",
+      "config",
+      "prompt_name"
+    ],
+    "title": "OptimizePromptJobRequest",
+    "description": "Request to optimize a prompt."
+  },
+  "OptimizePromptResponse": {
+    "properties": {
+      "optimization_job_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Optimization Job Id"
+      }
+    },
+    "type": "object",
+    "required": [
+      "optimization_job_id"
+    ],
+    "title": "OptimizePromptResponse",
+    "description": "Response from optimizing a prompt."
+  },
+  "PlaygroundPromptCanvasPayload": {
+    "properties": {
+      "messages": {
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/AIMessage"
+            },
+            {
+              "$ref": "#/components/schemas/HumanMessage"
+            },
+            {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            {
+              "$ref": "#/components/schemas/SystemMessage"
+            },
+            {
+              "$ref": "#/components/schemas/FunctionMessage"
+            },
+            {
+              "$ref": "#/components/schemas/ToolMessage"
+            },
+            {
+              "$ref": "#/components/schemas/AIMessageChunk"
+            },
+            {
+              "$ref": "#/components/schemas/HumanMessageChunk"
+            },
+            {
+              "$ref": "#/components/schemas/ChatMessageChunk"
+            },
+            {
+              "$ref": "#/components/schemas/SystemMessageChunk"
+            },
+            {
+              "$ref": "#/components/schemas/FunctionMessageChunk"
+            },
+            {
+              "$ref": "#/components/schemas/ToolMessageChunk"
+            }
+          ]
+        },
+        "type": "array",
+        "title": "Messages"
+      },
+      "highlighted": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Highlight"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "artifact": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Artifact"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "artifact_length": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "shortest",
+              "short",
+              "long",
+              "longest"
+            ]
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Artifact Length"
+      },
+      "reading_level": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "child",
+              "teenager",
+              "college",
+              "phd"
+            ]
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Reading Level"
+      },
+      "custom_action": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Custom Action"
+      },
+      "template_format": {
+        "type": "string",
+        "enum": [
+          "f-string",
+          "mustache"
+        ],
+        "title": "Template Format"
+      },
+      "secrets": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object",
+        "title": "Secrets"
+      }
+    },
+    "type": "object",
+    "required": [
+      "messages",
+      "template_format",
+      "secrets"
+    ],
+    "title": "PlaygroundPromptCanvasPayload"
+  },
+  "PromptOptimizationJob": {
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Id"
+      },
+      "repo_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Repo Id"
+      },
+      "status": {
+        "$ref": "#/components/schemas/EPromptOptimizationJobStatus"
+      },
+      "tenant_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Tenant Id"
+      },
+      "algorithm": {
+        "$ref": "#/components/schemas/EPromptOptimizationAlgorithm"
+      },
+      "config": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PromptimConfig"
+          },
+          {
+            "$ref": "#/components/schemas/DemoConfig"
+          }
+        ],
+        "title": "Config"
+      },
+      "results": {
+        "items": {
+          "$ref": "#/components/schemas/PromptOptimizationResult"
+        },
+        "type": "array",
+        "title": "Results"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Created At"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Updated At"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "repo_id",
+      "status",
+      "tenant_id",
+      "algorithm",
+      "config",
+      "created_at",
+      "updated_at"
+    ],
+    "title": "PromptOptimizationJob"
+  },
+  "PromptOptimizationJobCreate": {
+    "properties": {
+      "algorithm": {
+        "$ref": "#/components/schemas/EPromptOptimizationAlgorithm"
+      },
+      "config": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PromptimConfig"
+          },
+          {
+            "$ref": "#/components/schemas/DemoConfig"
+          }
+        ],
+        "title": "Config"
+      }
+    },
+    "type": "object",
+    "required": [
+      "algorithm",
+      "config"
+    ],
+    "title": "PromptOptimizationJobCreate"
+  },
+  "PromptOptimizationJobLog": {
+    "properties": {
+      "log_type": {
+        "$ref": "#/components/schemas/EPromptOptimizationJobLogType"
+      },
+      "message": {
+        "type": "string",
+        "title": "Message"
+      },
+      "data": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Data"
+      },
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Id"
+      },
+      "job_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Job Id"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Created At"
+      }
+    },
+    "type": "object",
+    "required": [
+      "log_type",
+      "message",
+      "id",
+      "job_id",
+      "created_at"
+    ],
+    "title": "PromptOptimizationJobLog"
+  },
+  "PromptOptimizationJobLogCreate": {
+    "properties": {
+      "log_type": {
+        "$ref": "#/components/schemas/EPromptOptimizationJobLogType"
+      },
+      "message": {
+        "type": "string",
+        "title": "Message"
+      },
+      "data": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Data"
+      }
+    },
+    "type": "object",
+    "required": [
+      "log_type",
+      "message"
+    ],
+    "title": "PromptOptimizationJobLogCreate"
+  },
+  "PromptOptimizationJobUpdate": {
+    "properties": {
+      "status": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/EPromptOptimizationJobStatus"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "result": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PromptOptimizationResult"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "type": "object",
+    "title": "PromptOptimizationJobUpdate"
+  },
+  "PromptOptimizationJobWithLogs": {
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Id"
+      },
+      "repo_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Repo Id"
+      },
+      "status": {
+        "$ref": "#/components/schemas/EPromptOptimizationJobStatus"
+      },
+      "tenant_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Tenant Id"
+      },
+      "algorithm": {
+        "$ref": "#/components/schemas/EPromptOptimizationAlgorithm"
+      },
+      "config": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PromptimConfig"
+          },
+          {
+            "$ref": "#/components/schemas/DemoConfig"
+          }
+        ],
+        "title": "Config"
+      },
+      "results": {
+        "items": {
+          "$ref": "#/components/schemas/PromptOptimizationResult"
+        },
+        "type": "array",
+        "title": "Results"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Created At"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Updated At"
+      },
+      "logs": {
+        "items": {
+          "$ref": "#/components/schemas/PromptOptimizationJobLog"
+        },
+        "type": "array",
+        "title": "Logs"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "repo_id",
+      "status",
+      "tenant_id",
+      "algorithm",
+      "config",
+      "created_at",
+      "updated_at",
+      "logs"
+    ],
+    "title": "PromptOptimizationJobWithLogs"
+  },
+  "PromptOptimizationResult": {
+    "properties": {
+      "timestamp": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Timestamp"
+      },
+      "x": {
+        "type": "number",
+        "title": "X"
+      },
+      "y": {
+        "type": "number",
+        "title": "Y"
+      }
+    },
+    "type": "object",
+    "required": [
+      "timestamp",
+      "x",
+      "y"
+    ],
+    "title": "PromptOptimizationResult"
+  },
+  "PromptWebhook": {
+    "properties": {
+      "url": {
+        "type": "string",
+        "minLength": 1,
+        "format": "uri",
+        "title": "Url"
+      },
+      "headers": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Headers"
+      },
+      "include_prompts": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Include Prompts"
+      },
+      "exclude_prompts": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Exclude Prompts"
+      },
+      "triggers": {
+        "items": {
+          "$ref": "#/components/schemas/EPromptWebhookTrigger"
+        },
+        "type": "array",
+        "title": "Triggers"
+      },
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Id"
+      },
+      "tenant_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Tenant Id"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Created At"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Updated At"
+      }
+    },
+    "type": "object",
+    "required": [
+      "url",
+      "id",
+      "tenant_id",
+      "created_at",
+      "updated_at"
+    ],
+    "title": "PromptWebhook",
+    "description": "Schema for a prompt webhook."
+  },
+  "PromptWebhookBase": {
+    "properties": {
+      "url": {
+        "type": "string",
+        "minLength": 1,
+        "format": "uri",
+        "title": "Url"
+      },
+      "headers": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Headers"
+      },
+      "include_prompts": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Include Prompts"
+      },
+      "exclude_prompts": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Exclude Prompts"
+      },
+      "triggers": {
+        "items": {
+          "$ref": "#/components/schemas/EPromptWebhookTrigger"
+        },
+        "type": "array",
+        "title": "Triggers"
+      }
+    },
+    "type": "object",
+    "required": [
+      "url"
+    ],
+    "title": "PromptWebhookBase",
+    "description": "Base schema for prompt webhooks."
+  },
+  "PromptWebhookCreate": {
+    "properties": {
+      "url": {
+        "type": "string",
+        "minLength": 1,
+        "format": "uri",
+        "title": "Url"
+      },
+      "headers": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Headers"
+      },
+      "include_prompts": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Include Prompts"
+      },
+      "exclude_prompts": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Exclude Prompts"
+      },
+      "triggers": {
+        "items": {
+          "$ref": "#/components/schemas/EPromptWebhookTrigger"
+        },
+        "type": "array",
+        "title": "Triggers"
+      },
+      "id": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Id"
+      }
+    },
+    "type": "object",
+    "required": [
+      "url"
+    ],
+    "title": "PromptWebhookCreate",
+    "description": "Schema for creating a prompt webhook."
+  },
+  "PromptWebhookPayload": {
+    "properties": {
+      "prompt_id": {
+        "type": "string",
+        "title": "Prompt Id"
+      },
+      "prompt_name": {
+        "type": "string",
+        "title": "Prompt Name"
+      },
+      "manifest": {
+        "additionalProperties": true,
+        "type": "object",
+        "title": "Manifest"
+      },
+      "commit_hash": {
+        "type": "string",
+        "title": "Commit Hash"
+      },
+      "created_at": {
+        "type": "string",
+        "title": "Created At"
+      },
+      "created_by": {
+        "type": "string",
+        "title": "Created By"
+      },
+      "event": {
+        "$ref": "#/components/schemas/EPromptWebhookTrigger"
+      },
+      "tag_name": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Tag Name"
+      }
+    },
+    "type": "object",
+    "required": [
+      "prompt_id",
+      "prompt_name",
+      "manifest",
+      "commit_hash",
+      "created_at",
+      "created_by",
+      "event"
+    ],
+    "title": "PromptWebhookPayload"
+  },
+  "PromptWebhookTest": {
+    "properties": {
+      "webhook": {
+        "$ref": "#/components/schemas/PromptWebhookBase"
+      },
+      "payload": {
+        "$ref": "#/components/schemas/PromptWebhookPayload"
+      }
+    },
+    "type": "object",
+    "required": [
+      "webhook",
+      "payload"
+    ],
+    "title": "PromptWebhookTest",
+    "description": "Schema for testing a prompt webhook."
+  },
+  "PromptWebhookUpdate": {
+    "properties": {
+      "include_prompts": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Include Prompts"
+      },
+      "exclude_prompts": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Exclude Prompts"
+      },
+      "url": {
+        "anyOf": [
+          {
+            "type": "string",
+            "minLength": 1,
+            "format": "uri"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Url"
+      },
+      "headers": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Headers"
+      },
+      "triggers": {
+        "anyOf": [
+          {
+            "items": {
+              "$ref": "#/components/schemas/EPromptWebhookTrigger"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Triggers"
+      }
+    },
+    "type": "object",
+    "title": "PromptWebhookUpdate",
+    "description": "Schema for updating a prompt webhook."
+  },
+  "PromptimConfig": {
+    "properties": {
+      "message_index": {
+        "type": "integer",
+        "title": "Message Index"
+      },
+      "task_description": {
+        "type": "string",
+        "title": "Task Description"
+      },
+      "dataset_name": {
+        "type": "string",
+        "title": "Dataset Name"
+      },
+      "train_split": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Train Split"
+      },
+      "dev_split": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Dev Split"
+      },
+      "test_split": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Test Split"
+      },
+      "evaluators": {
+        "items": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "type": "array",
+        "title": "Evaluators"
+      },
+      "num_epochs": {
+        "type": "integer",
+        "title": "Num Epochs"
+      },
+      "auto_commit": {
+        "type": "boolean",
+        "title": "Auto Commit"
+      }
+    },
+    "type": "object",
+    "required": [
+      "message_index",
+      "task_description",
+      "dataset_name",
+      "train_split",
+      "dev_split",
+      "test_split",
+      "evaluators",
+      "num_epochs",
+      "auto_commit"
+    ],
+    "title": "PromptimConfig"
+  },
+  "RepoExampleResponse": {
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Id"
+      },
+      "start_time": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Start Time"
+      },
+      "inputs": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Inputs"
+      },
+      "outputs": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Outputs"
+      },
+      "session_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Session Id"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "session_id"
+    ],
+    "title": "RepoExampleResponse",
+    "description": "Response model for example runs"
+  },
+  "RepoTag": {
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Id"
+      },
+      "repo_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Repo Id"
+      },
+      "commit_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Commit Id"
+      },
+      "commit_hash": {
+        "type": "string",
+        "title": "Commit Hash"
+      },
+      "tag_name": {
+        "type": "string",
+        "title": "Tag Name"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Created At"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Updated At"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "repo_id",
+      "commit_id",
+      "commit_hash",
+      "tag_name",
+      "created_at",
+      "updated_at"
+    ],
+    "title": "RepoTag",
+    "description": "Fields for a prompt tag"
+  },
+  "RepoTagRequest": {
+    "properties": {
+      "tag_name": {
+        "type": "string",
+        "title": "Tag Name"
+      },
+      "commit_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Commit Id"
+      },
+      "skip_webhooks": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          }
+        ],
+        "title": "Skip Webhooks",
+        "default": false
+      }
+    },
+    "type": "object",
+    "required": [
+      "tag_name",
+      "commit_id"
+    ],
+    "title": "RepoTagRequest",
+    "description": "Fields to create a prompt tag"
+  },
+  "RepoUpdateTagRequest": {
+    "properties": {
+      "commit_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Commit Id"
+      },
+      "skip_webhooks": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array"
+          }
+        ],
+        "title": "Skip Webhooks",
+        "default": false
+      }
+    },
+    "type": "object",
+    "required": [
+      "commit_id"
+    ],
+    "title": "RepoUpdateTagRequest",
+    "description": "Fields to update a prompt tag"
+  },
+  "RepoWithLookups": {
+    "properties": {
+      "repo_handle": {
+        "type": "string",
+        "title": "Repo Handle"
+      },
+      "description": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Description"
+      },
+      "readme": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Readme"
+      },
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Id"
+      },
+      "tenant_id": {
+        "type": "string",
+        "format": "uuid",
+        "title": "Tenant Id"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Created At"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Updated At"
+      },
+      "is_public": {
+        "type": "boolean",
+        "title": "Is Public"
+      },
+      "is_archived": {
+        "type": "boolean",
+        "title": "Is Archived"
+      },
+      "tags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array",
+        "title": "Tags"
+      },
+      "original_repo_id": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Original Repo Id"
+      },
+      "upstream_repo_id": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Upstream Repo Id"
+      },
+      "owner": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Owner"
+      },
+      "full_name": {
+        "type": "string",
+        "title": "Full Name"
+      },
+      "num_likes": {
+        "type": "integer",
+        "title": "Num Likes"
+      },
+      "num_downloads": {
+        "type": "integer",
+        "title": "Num Downloads"
+      },
+      "num_views": {
+        "type": "integer",
+        "title": "Num Views"
+      },
+      "liked_by_auth_user": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Liked By Auth User"
+      },
+      "last_commit_hash": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Last Commit Hash"
+      },
+      "num_commits": {
+        "type": "integer",
+        "title": "Num Commits"
+      },
+      "original_repo_full_name": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Original Repo Full Name"
+      },
+      "upstream_repo_full_name": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Upstream Repo Full Name"
+      },
+      "latest_commit_manifest": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/CommitManifestResponse"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "type": "object",
+    "required": [
+      "repo_handle",
+      "id",
+      "tenant_id",
+      "created_at",
+      "updated_at",
+      "is_public",
+      "is_archived",
+      "tags",
+      "owner",
+      "full_name",
+      "num_likes",
+      "num_downloads",
+      "num_views",
+      "num_commits"
+    ],
+    "title": "RepoWithLookups",
+    "description": "All database fields for repos, plus helpful computed fields."
+  },
+  "UpdateRepoRequest": {
+    "properties": {
+      "description": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Description"
+      },
+      "readme": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Readme"
+      },
+      "tags": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Tags"
+      },
+      "is_public": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Is Public"
+      },
+      "is_archived": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Is Archived"
+      }
+    },
+    "type": "object",
+    "title": "UpdateRepoRequest",
+    "description": "Fields to update a repo"
+  }
+}

--- a/reference/openapi/langchain/langsmith/MANIFEST.md
+++ b/reference/openapi/langchain/langsmith/MANIFEST.md
@@ -34,6 +34,7 @@ The core LangSmith API provides endpoints for:
 |------|--------|------|-------|
 | 2025-11-26 | Initial fetch | 635K | v0.1.0 |
 | 2025-11-28 | Refresh for #350 | 639K | Dataset API validation |
+| 2025-11-29 | Refresh for #404 | 638K | Structured output prompt validation |
 
 ## Refresh Command
 

--- a/reference/research/402-structured-prompts-openapi-validation.md
+++ b/reference/research/402-structured-prompts-openapi-validation.md
@@ -1,0 +1,214 @@
+# Structured Output Prompts OpenAPI Validation Report
+
+**Issue**: [#404](https://github.com/codekiln/langstar/issues/404) - Validate structured output prompt design against LangSmith OpenAPI spec
+**Milestone**: [#7 - ls-prompt-structured-outputs](https://github.com/codekiln/langstar/milestone/7)
+**Date**: 2025-11-29
+
+## Executive Summary
+
+This report validates the research findings from [#398](https://github.com/codekiln/langstar/issues/398) against the LangSmith OpenAPI specification. All key findings are **confirmed** by the spec, with important clarifications about the flexible manifest structure.
+
+## Validation Results
+
+### ✅ 1. Endpoint Validation
+
+**Research Finding**: POST /commits/{owner}/{repo}/ endpoint for creating prompt commits
+
+**OpenAPI Validation**:
+- **Status**: ✅ **CONFIRMED**
+- **Path**: `/api/v1/commits/{owner}/{repo}`
+- **Method**: POST
+- **Request Schema**: `CreateRepoCommitRequest`
+- **Location**: `reference/api-specs/langsmith/prompt-endpoints.json:1-199`
+
+**Schema Details**:
+```json
+{
+  "properties": {
+    "manifest": {
+      "additionalProperties": true,
+      "type": "object",
+      "title": "Manifest"
+    },
+    "parent_commit": {
+      "anyOf": [{"type": "string"}, {"type": "null"}],
+      "title": "Parent Commit"
+    },
+    "example_run_ids": {
+      "anyOf": [
+        {"items": {"type": "string", "format": "uuid"}, "type": "array"},
+        {"type": "null"}
+      ]
+    },
+    "skip_webhooks": {
+      "anyOf": [{"type": "boolean"}, {"items": {"type": "string", "format": "uuid"}, "type": "array"}],
+      "default": false
+    }
+  },
+  "required": ["manifest"]
+}
+```
+
+**Key Observations**:
+- The `manifest` field is **required**
+- `manifest` allows arbitrary JSON (`additionalProperties: true`)
+- No validation of internal manifest structure by the API
+
+### ✅ 2. Manifest Structure Validation
+
+**Research Finding**: Manifests use LC-JSON format with specific structure
+
+**OpenAPI Validation**:
+- **Status**: ✅ **CONFIRMED WITH CLARIFICATION**
+- **Schema**: `CreateRepoCommitRequest.manifest` and `CommitManifestResponse.manifest`
+- **Type**: `object` with `additionalProperties: true`
+
+**Clarification**:
+The OpenAPI spec intentionally **does not constrain** the manifest structure. This is by design - the API treats manifests as opaque JSON blobs, allowing LangChain to evolve the serialization format without API changes.
+
+**Implication for Langstar**:
+- Langstar must implement LC-JSON serialization logic in SDK
+- No server-side validation of manifest structure
+- Client-side schema validation recommended before pushing
+
+### ✅ 3. Schema Field Validation
+
+**Research Finding**: `StructuredPrompt` has `schema_` and `structured_output_kwargs` fields
+
+**OpenAPI Validation**:
+- **Status**: ✅ **CONFIRMED AS CLIENT-SIDE CONCERN**
+- The OpenAPI spec does **not** define these fields because they exist within the opaque `manifest` object
+- These fields are part of the LC-JSON format (LangChain's serialization)
+
+**LC-JSON Structure** (from research experiments):
+```json
+{
+  "lc": 1,
+  "type": "constructor",
+  "id": ["langchain_core", "prompts", "structured", "StructuredPrompt"],
+  "kwargs": {
+    "messages": [...],
+    "schema_": {
+      "type": "object",
+      "properties": {...}
+    },
+    "structured_output_kwargs": {
+      "method": "json_schema"
+    }
+  }
+}
+```
+
+**Validation**:
+- ✅ `schema_` field exists in `kwargs` (stores JSON Schema dict)
+- ✅ `structured_output_kwargs.method` stores the method selection
+
+### ✅ 4. Method Options Validation
+
+**Research Finding**: Two methods supported: `"json_schema"` and `"function_calling"`
+
+**OpenAPI Validation**:
+- **Status**: ✅ **CONFIRMED AS CLIENT-SIDE CONCERN**
+- Not enforced by API (opaque manifest)
+- Validated by experiments in #398
+
+**From Research Experiments**:
+Both methods work when included in the manifest's `structured_output_kwargs`:
+- `"json_schema"` - Use JSON Schema mode
+- `"function_calling"` - Use function calling mode
+
+**No API-level enum validation** - this is enforced by LangChain deserialization.
+
+## Discrepancies
+
+### None Found
+
+All research findings align with the OpenAPI spec. The key insight is understanding the **API boundary**:
+
+| Layer | Validation | Ownership |
+|-------|------------|-----------|
+| API Layer | `manifest` is valid JSON object | LangSmith API |
+| SDK Layer | LC-JSON format, schema_ structure, method values | Langstar SDK |
+
+## Key Findings Summary
+
+| Finding | Research | OpenAPI Spec | Status |
+|---------|----------|--------------|--------|
+| POST /commits endpoint | ✅ Documented | ✅ Exists | ✅ Match |
+| Manifest is flexible JSON | ✅ Documented | ✅ `additionalProperties: true` | ✅ Match |
+| LC-JSON format | ✅ Documented | ⚪ Out of scope | ✅ SDK concern |
+| `schema_` field | ✅ In experiments | ⚪ Not in spec | ✅ SDK concern |
+| `structured_output_kwargs` | ✅ In experiments | ⚪ Not in spec | ✅ SDK concern |
+| Method options | ✅ Validated | ⚪ Not enumerated | ✅ SDK concern |
+
+**Legend**:
+- ✅ Confirmed
+- ⚪ Expected to be out of scope
+- ❌ Conflict (none found)
+
+## Implementation Guidance
+
+### For Langstar SDK (#405-#406)
+
+1. **Create StructuredPrompt Type**
+   - Fields: `messages`, `schema_`, `structured_output_kwargs`
+   - Validate `schema_` is valid JSON Schema
+   - Validate `method` is "json_schema" or "function_calling"
+
+2. **Implement LC-JSON Serialization**
+   - Serialize to format shown in research experiments
+   - Use module path: `["langchain_core", "prompts", "structured", "StructuredPrompt"]`
+   - Support nested message templates
+
+3. **Add Client Methods**
+   - `push_structured_prompt()` - Serialize and POST to /commits
+   - `pull_structured_prompt()` - GET from /commits and deserialize
+
+### For Langstar CLI (#407)
+
+1. **Add `--schema` Flag**
+   - Accept JSON Schema file path
+   - Load and validate schema
+   - Pass to SDK push method
+
+2. **Add `--method` Flag**
+   - Values: `json_schema`, `function_calling`
+   - Default: `json_schema`
+
+## References
+
+### API Spec Fragments
+- **Endpoints**: `reference/api-specs/langsmith/prompt-endpoints.json`
+- **Schemas**: `reference/api-specs/langsmith/prompt-schemas.json`
+- **Full Spec**: `reference/openapi/langchain/langsmith/openapi.json`
+
+### Related Research
+- [#398 Research Report](../../docs/research/398-structured-output-prompts-scout.md)
+- [#403 Design Consistency](https://github.com/codekiln/langstar/issues/403)
+
+### OpenAPI Details
+- **Provenance**: Fetched 2025-11-29 from `https://api.smith.langchain.com/openapi.json`
+- **Size**: 638K
+- **MANIFEST**: `reference/openapi/langchain/langsmith/MANIFEST.md`
+
+### Extraction Commands Used
+```bash
+# Extract prompt endpoints
+jq '.paths | with_entries(select(.key | test("^/api/v1/(repos|commits)")))' \
+  openapi.json > ../../api-specs/langsmith/prompt-endpoints.json
+
+# Extract prompt schemas
+jq '.components.schemas | with_entries(select(.key | test("[Rr]epo|[Cc]ommit|[Pp]rompt|[Mm]anifest"; "i")))' \
+  openapi.json > ../../api-specs/langsmith/prompt-schemas.json
+```
+
+## Conclusion
+
+The research findings from #398 are **validated and accurate**. The OpenAPI spec confirms:
+
+1. ✅ POST /commits endpoint exists with correct structure
+2. ✅ Manifest field is flexible JSON (by design)
+3. ✅ LC-JSON format is client-side serialization (not API-enforced)
+4. ✅ Schema and method handling is SDK responsibility
+
+**No blocking issues** identified. Implementation can proceed to SDK phase (#405-#406).


### PR DESCRIPTION
## Summary

This PR completes the OpenAPI validation phase (Wave 1, Issue #404) for structured output prompt support. All research findings from #398 have been validated against the LangSmith OpenAPI specification.

## Changes

- ✅ Fetched latest LangSmith OpenAPI spec (638K, 2025-11-29)
- ✅ Extracted prompt/commit endpoints to `reference/api-specs/langsmith/prompt-endpoints.json` (45K)
- ✅ Extracted prompt/commit schemas to `reference/api-specs/langsmith/prompt-schemas.json` (37K)
- ✅ Updated `MANIFEST.md` with provenance metadata
- ✅ Updated `FRAGMENTS.md` with new jq extraction queries
- ✅ Created comprehensive validation report at `reference/research/402-structured-prompts-openapi-validation.md`

## Key Validations

- ✅ POST /commits/{owner}/{repo} endpoint confirmed
- ✅ Manifest structure validated (flexible JSON, `additionalProperties: true`)
- ✅ LC-JSON format confirmed as SDK concern (not API-enforced)
- ✅ `schema_` and `structured_output_kwargs` fields confirmed in experiments
- ✅ Method options (`json_schema`, `function_calling`) validated

## Findings

**All research findings from #398 are confirmed.** No discrepancies found. The OpenAPI spec intentionally treats manifests as opaque JSON blobs, allowing SDK flexibility.

**No blocking issues** for proceeding to SDK implementation (#405-#406).

## Related Issues

Fixes #404

Part of milestone [#7 - ls-prompt-structured-outputs](https://github.com/codekiln/langstar/milestone/7)

## Test Plan

- [x] OpenAPI spec fetched successfully
- [x] Schema fragments extracted with documented jq queries
- [x] MANIFEST.md updated with provenance
- [x] FRAGMENTS.md updated with extraction commands
- [x] Validation report covers all research findings
- [x] All checklist items from #404 completed

## Next Steps

Ready for Wave 2: SDK Implementation
- Issue #405: SDK types (StructuredPrompt, LC-JSON)
- Issue #406: SDK client methods (push/pull with schema)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)