### PR TITLE
📚 docs(pr-workflow): add critical guidance on handling review comments

### DIFF
--- a/.claude/commands/pr-workflow.md
+++ b/.claude/commands/pr-workflow.md
@@ -324,6 +324,36 @@ EOF
 )"
      ```
 
+   **CRITICAL: Never Promise Future Work**
+
+   **DO NOT** reply with "I'll track this in a follow-up issue" or "I'll create a ticket for this" unless you IMMEDIATELY:
+   1. Create the GitHub issue RIGHT NOW
+   2. Add it to the correct milestone
+   3. Link it as a sub-issue if applicable
+   4. Reference the issue number in your comment reply
+   5. Add a TODO comment in the code with the issue reference
+
+   **Why:** Each GitHub issue gets a fresh Claude Code context. You will NOT remember to create that issue later, and the promise becomes technical debt.
+
+   **Decision Tree for Review Comments:**
+   - **Small change (< 20 lines)?** → Fix it NOW in this PR
+   - **Medium change (20-100 lines)?** → Fix it NOW in this PR (prefer this)
+   - **Large/breaking change?** → ONLY defer if you create the issue+milestone+sub-issue immediately
+
+   **Cost of deferring:**
+   - Create GitHub issue → Link to milestone → Schedule → Create PR → Review → Wait for CI = ~30+ minutes overhead
+   - vs. fixing small issues now = ~2-5 minutes
+
+   **Example GOOD response:**
+   ```
+   Good point about consistency. Fixed in commit abc123: Updated dataset.rs to match this pattern.
+   ```
+
+   **Example BAD response (never do this):**
+   ```
+   Good point. I'll track updating dataset.rs in a follow-up issue for consistency.
+   ```
+
 3. **Check if branch needs rebasing:**
    ```bash
    # Check if base branch has new commits


### PR DESCRIPTION
## Summary
- Adds critical "Never Promise Future Work" section to pr-workflow command
- Provides clear decision tree for handling review comments
- Emphasizes fixing issues NOW vs. deferring with overhead analysis
- Includes examples of good vs. bad responses

## Problem
During PR #397 review response, I made the mistake of saying "I'll track updating dataset.rs in a follow-up issue" without immediately creating that issue. This creates technical debt because:
- Each GitHub issue gets a fresh Claude Code context
- Future promises are forgotten without immediate action
- The overhead of defer → issue → milestone → PR → review >> fix now

## Solution
Document this pattern explicitly in the pr-workflow command to prevent future occurrences.

## Changes
- Added "CRITICAL: Never Promise Future Work" section after "Address each review comment"
- Provided decision tree: small changes → fix now, large changes → only defer if issue created immediately
- Calculated real overhead cost: defer workflow ~30+ min vs. fix now ~2-5 min
- Added concrete examples of good vs. bad comment responses

## Test Plan
- [x] Documentation is clear and actionable
- [x] Examples provide concrete guidance
- [x] Decision tree covers common scenarios

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>