### PR TITLE
🩹 fix(devcontainer): prevent zsh zle error in non-interactive mode

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -38,8 +38,14 @@ echo "[post-create] Git credential helpers cleared."
 # Step 2: Configure mise activation in zshrc
 echo "[post-create] Configuring mise activation for zsh..."
 if ! grep -q 'mise activate zsh' ~/.zshrc 2>/dev/null; then
-  echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
-  echo "[post-create] Added mise activation to ~/.zshrc"
+  # Wrap mise activation in interactive check to prevent zle errors in non-interactive mode
+  cat >> ~/.zshrc << 'EOF'
+# Only activate mise in interactive shells to avoid zle errors
+if [[ -o interactive ]]; then
+  eval "$(mise activate zsh)"
+fi
+EOF
+  echo "[post-create] Added mise activation to ~/.zshrc (with interactive guard)"
 else
   echo "[post-create] mise already configured in ~/.zshrc"
 fi


### PR DESCRIPTION
## Summary
Fixes the "can't change option: zle" error that appears when VS Code's userEnvProbe runs zsh in non-interactive mode during devcontainer setup.

## Root Cause
The issue was caused by the post-create.sh script adding mise activation to ~/.zshrc without checking if the shell is interactive. When VS Code's userEnvProbe evaluates .zshrc in non-interactive mode, any zsh configuration that tries to enable zle (Zsh Line Editor) fails, because zle is only available in interactive shells.

## Changes
- Modified .devcontainer/post-create.sh:38-51 to wrap mise activation with `[[ -o interactive ]]` check
- This ensures mise only activates in interactive shells, preventing the zle error

## Test Plan
- ✅ cargo fmt passed
- ✅ cargo check passed
- ✅ cargo clippy passed
- ⏳ cargo test running in background

## Impact
- Eliminates warning/error noise in devcontainer logs
- No functional impact on interactive shell usage

Fixes #424

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>