### PR TITLE
🩹 fix(devcontainer): remove duplicate Rust installation from mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,8 +5,8 @@
 # Python 3.11+ is required for Spec-Kit (github/spec-kit)
 python = "3.11"
 
-# Rust is required for langstar CLI development
-rust = "latest"
+# Rust is managed by devcontainer feature (ghcr.io/devcontainers/features/rust:1)
+# Not managed by mise to avoid duplicate installation
 
 # Node.js version matches devcontainer base image
 # Managed by devcontainer, not by mise


### PR DESCRIPTION
## Summary
Fixes duplicate Rust installation by removing `rust = "latest"` from `mise.toml`. Rust is already installed by the devcontainer feature (`ghcr.io/devcontainers/features/rust:1`), so having it in mise.toml caused it to be installed twice.

## Changes
- Removed `rust = "latest"` from `mise.toml`
- Added explanatory comment documenting that Rust is managed by devcontainer feature
- This prevents duplicate installation during devcontainer setup

## Impact
- ✅ Eliminates wasted build time from installing Rust twice
- ✅ Reduces unnecessary disk usage
- ✅ Prevents potential version conflicts between two installations
- ✅ Improves devcontainer rebuild performance

## Related Issues
Fixes #425

## Test Plan
- [x] Verified change only removes `rust = "latest"` from mise.toml
- [x] Confirmed devcontainer feature still declares Rust installation
- [x] Added clear documentation explaining why Rust is not in mise.toml

## Testing Notes
To fully test this change, rebuild the devcontainer and verify:
1. Rust is still available (`rustc --version`, `cargo --version`)
2. Only one Rust installation occurs in the build logs
3. mise only manages Python (not Rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)