### PR TITLE
🔧 build(devcontainer): change default editor from nano to vim

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -86,8 +86,8 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 ENV SHELL=/bin/zsh
 
 # Set the default editor and visual
-ENV EDITOR=nano
-ENV VISUAL=nano
+ENV EDITOR=vim
+ENV VISUAL=vim
 
 # Default powerline10k theme
 ARG ZSH_IN_DOCKER_VERSION=1.2.0


### PR DESCRIPTION
## Summary
Changes the default terminal editor in the devcontainer from nano to vim by updating the EDITOR and VISUAL environment variables in the Dockerfile.

## Changes
- Updated `ENV EDITOR=nano` to `ENV EDITOR=vim` in `.devcontainer/Dockerfile:89`
- Updated `ENV VISUAL=nano` to `ENV VISUAL=vim` in `.devcontainer/Dockerfile:90`

## Related Issues
Fixes #439

## Test Plan
- [ ] Verify vim is installed in the devcontainer
- [ ] Rebuild the devcontainer and verify `echo $EDITOR` outputs `vim`
- [ ] Verify `echo $VISUAL` outputs `vim`
- [ ] Test that git commit opens vim instead of nano
- [ ] Test that `/memory` command uses vim

## Impact
This change affects all tools that respect the EDITOR/VISUAL environment variables:
- Git operations (commit messages, interactive rebase, etc.)
- Claude Code memory commands
- Other CLI tools that launch editors

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)