### PR TITLE
🩹 fix(devcontainer): remove SSH URL rewrites before mise install

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -32,7 +32,18 @@ git config --unset-all credential.https://gist.github.com.helper 2>/dev/null || 
 # The empty string resets the helper list (overriding system config)
 # This ensures no credential helpers are active during mise install
 git config --global --replace-all credential.helper "" ".*" 2>/dev/null || true
-echo "[post-create] Git credential helpers cleared."
+
+# Remove SSH URL rewrite rules that would force SSH protocol instead of HTTPS
+# VS Code Dev Containers may copy host machine's ~/.gitconfig which can contain:
+#   [url "git@github.com:"]
+#       insteadof = https://github.com/
+# This would cause mise to try SSH authentication (requiring SSH keys) instead of
+# HTTPS authentication (which works without credentials for public repos).
+# We remove these rules here to ensure mise install uses HTTPS protocol.
+git config --global --unset url.git@github.com:.insteadof 2>/dev/null || true
+git config --unset url.git@github.com:.insteadof 2>/dev/null || true
+
+echo "[post-create] Git credential helpers and SSH URL rewrites cleared."
 
 # Step 2: Configure mise activation in zshrc
 echo "[post-create] Configuring mise activation for zsh..."


### PR DESCRIPTION
## Summary

Fixes the SSH authentication error that occurs when `mise install` tries to install Python 3.11 after rebuilding the devcontainer.

## Problem

After rebuilding the devcontainer, mise fails to install Python 3.11 with:
```
mise ERROR Failed to install core:python@3.11: 
   0: Credentials provided for "git@github.com:pyenv/pyenv.git" were not accepted by the remote
   1: git@github.com: Permission denied (publickey).
```

## Root Cause

This is a timing/ordering issue:

1. VS Code Dev Containers copies host machine's `~/.gitconfig` which may contain SSH URL rewrite rules:
   ```
   [url "git@github.com:"]
       insteadof = https://github.com/
   ```
2. `postCreateCommand` runs `post-create.sh` (which calls `mise install`)
3. `postStartCommand` runs `setup-github-auth.sh` (which removes SSH URL rewrite rules)
4. **Problem**: `postCreateCommand` runs BEFORE `postStartCommand`, so mise tries to install Python before SSH URL rewrites are removed

## Solution

Update `post-create.sh` to remove SSH URL rewrite rules in Step 1, matching the approach in `setup-github-auth.sh:95-96`. This ensures SSH rewrites are removed BEFORE `mise install` runs.

## Changes

- Added `git config --global --unset url.git@github.com:.insteadof` to post-create.sh
- Added `git config --unset url.git@github.com:.insteadof` to post-create.sh
- Added explanatory comments about why SSH URL rewrite removal is needed
- Updated echo message to reflect both credential helper and SSH rewrite clearing

## Test Plan

- [x] Reviewed the fix matches the pattern from setup-github-auth.sh:95-96
- [x] Verified the fix is placed in the correct location (Step 1, before mise install)
- [x] Verified comments explain the timing issue clearly
- [ ] Manual testing: Rebuild devcontainer and verify mise install succeeds

## Related Issues

Fixes #437

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)