### PR TITLE
📚 docs: document docs/ and reference/ directories in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,14 @@ For commit message formatting, please follow @docs/dev/git-scm-conventions.md
 
 ### Basic principles - see @docs/dev/code-style-principles.md
 
-## Repository Structure
+## Supporting Repository Structures
 
 ### `docs/` - Project Documentation
 - `dev/` - Development guidelines, workflow docs, ADRs (see @docs/dev/README.md)
 - `examples/` - Example code and usage patterns
 - `implementation/` - Implementation plans and specifications
-- `research/` - Research reports and findings
-- `templates/` - Document templates
+- `research/` - Research reports and findings for specific internal issues
+- `templates/` - templates for milestone tickets and checklists 
 - `usage/` - Usage documentation and guides
 
 ### `reference/` - External Resources & Experiments
@@ -50,3 +50,11 @@ For commit message formatting, please follow @docs/dev/git-scm-conventions.md
 - `openapi/langchain/` - OpenAPI JSON specifications
 - `repo/` - Remote repository notes (see .claude/skills/setup-remote-repo-notes-dir knowledge management pattern)
 - `research/` - Research reports on external codebases
+
+### `tests/` - root-level fixtures for integration tests
+- see `tests/fixtures/test-graph-deployment/README.md` info about langsmith test deployment for integration tests
+
+### `wip/` - work in progress
+- gitignored
+- includes git worktrees for active in dev issues. `scripts/cleanup-closed-issue-worktrees.sh` and .claude/skills/git-worktrees creates and cleans up.
+- some txt files with debugging for active issues


### PR DESCRIPTION
## Summary

Adds high-level documentation of repository structure to AGENTS.md, helping AI agents understand the codebase organization without loading excessive context.

## Changes

- Added "Repository Structure" section to AGENTS.md documenting:
  - `docs/` directory and subdirectories (dev, examples, implementation, research, templates, usage)
  - `reference/` directory and subdirectories (api-specs, experiments, openapi, repo, research)
- Documentation is concise (~15 lines total for both directories)
- CLAUDE.md already properly sources AGENTS.md with `@AGENTS.md`
- Used @ symbols sparingly, referencing @docs/dev/README.md and .claude/skills/setup-remote-repo-notes-dir

## Related Issues

Fixes #450

## Test Plan

- [x] Verified AGENTS.md includes new directory documentation
- [x] Verified CLAUDE.md sources AGENTS.md correctly
- [x] Documentation is concise and provides clear purpose statements
- [x] @ file references used judiciously

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>