### PR TITLE
📚 docs: extract playground-settings OpenAPI schemas and validate

### DIFF
--- a/reference/api-specs/langsmith/FRAGMENTS.md
+++ b/reference/api-specs/langsmith/FRAGMENTS.md
@@ -30,6 +30,11 @@ These fragments are extracted subsets of the full OpenAPI spec, optimized for:
 | `evals-schemas.json` | 38K | Evaluation/feedback data types | See below | 2025-11-28 |
 | `prompt-endpoints.json` | 45K | Prompt repository/commit API endpoints | See below | 2025-11-29 |
 | `prompt-schemas.json` | 37K | Prompt/commit/manifest data types | See below | 2025-11-29 |
+| `playground-settings-endpoints.json` | 4.9K | Playground settings CRUD API endpoints | See below | 2025-12-01 |
+| `playground-settings-response.json` | 1.1K | PlaygroundSettingsResponse schema | See below | 2025-12-01 |
+| `playground-settings-create-request.json` | 0.8K | PlaygroundSettingsCreateRequest schema | See below | 2025-12-01 |
+| `playground-settings-update-request.json` | 0.8K | PlaygroundSettingsUpdateRequest schema | See below | 2025-12-01 |
+| `playground-saved-options.json` | 0.3K | PlaygroundSavedOptions schema | See below | 2025-12-01 |
 
 ## Extraction Commands
 
@@ -91,6 +96,26 @@ jq '.paths | with_entries(select(.key | test("^/api/v1/(repos|commits)")))' \
 # Prompt/commit/manifest schemas (all schemas containing "repo", "commit", "prompt", or "manifest")
 jq '.components.schemas | with_entries(select(.key | test("[Rr]epo|[Cc]ommit|[Pp]rompt|[Mm]anifest"; "i")))' \
   openapi.json > ../../api-specs/langsmith/prompt-schemas.json
+
+# Playground settings endpoints (all /api/v1/playground-settings paths)
+jq '.paths | with_entries(select(.key | test("^/api/v1/playground-settings")))' \
+  openapi.json > ../../api-specs/langsmith/playground-settings-endpoints.json
+
+# PlaygroundSettingsResponse schema
+jq '.components.schemas.PlaygroundSettingsResponse' \
+  openapi.json > ../../api-specs/langsmith/playground-settings-response.json
+
+# PlaygroundSettingsCreateRequest schema
+jq '.components.schemas.PlaygroundSettingsCreateRequest' \
+  openapi.json > ../../api-specs/langsmith/playground-settings-create-request.json
+
+# PlaygroundSettingsUpdateRequest schema
+jq '.components.schemas.PlaygroundSettingsUpdateRequest' \
+  openapi.json > ../../api-specs/langsmith/playground-settings-update-request.json
+
+# PlaygroundSavedOptions schema
+jq '.components.schemas.PlaygroundSavedOptions' \
+  openapi.json > ../../api-specs/langsmith/playground-saved-options.json
 ```
 
 ## Verification
@@ -119,3 +144,4 @@ jq '.paths | keys | map(select(contains("annotation-queue"))) | length' \
   - `../../research/334-openapi-validation.md` - Annotation queues validation
   - `../../research/347-openapi-validation.md` - Evaluations/feedback validation
   - `../../research/402-structured-prompts-openapi-validation.md` - Structured output prompts validation
+  - `../../research/461-openapi-validation.md` - Playground settings (model providers) validation

--- a/reference/api-specs/langsmith/playground-saved-options.json
+++ b/reference/api-specs/langsmith/playground-saved-options.json
@@ -1,0 +1,17 @@
+{
+  "properties": {
+    "requests_per_second": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Requests Per Second"
+    }
+  },
+  "type": "object",
+  "title": "PlaygroundSavedOptions"
+}

--- a/reference/api-specs/langsmith/playground-settings-create-request.json
+++ b/reference/api-specs/langsmith/playground-settings-create-request.json
@@ -1,0 +1,46 @@
+{
+  "properties": {
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Name"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Description"
+    },
+    "settings": {
+      "additionalProperties": true,
+      "type": "object",
+      "title": "Settings"
+    },
+    "options": {
+      "anyOf": [
+        {
+          "$ref": "#/components/schemas/PlaygroundSavedOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "required": [
+    "settings"
+  ],
+  "title": "PlaygroundSettingsCreateRequest"
+}

--- a/reference/api-specs/langsmith/playground-settings-endpoints.json
+++ b/reference/api-specs/langsmith/playground-settings-endpoints.json
@@ -1,0 +1,204 @@
+{
+  "/api/v1/playground-settings": {
+    "get": {
+      "tags": [
+        "playground-settings"
+      ],
+      "summary": "List Playground Settings",
+      "description": "Get all playground settings for this tenant id.",
+      "operationId": "list_playground_settings_api_v1_playground_settings_get",
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/PlaygroundSettingsResponse"
+                },
+                "type": "array",
+                "title": "Response List Playground Settings Api V1 Playground Settings Get"
+              }
+            }
+          }
+        }
+      },
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ]
+    },
+    "post": {
+      "tags": [
+        "playground-settings"
+      ],
+      "summary": "Create Playground Settings",
+      "description": "Create playground settings.",
+      "operationId": "create_playground_settings_api_v1_playground_settings_post",
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PlaygroundSettingsCreateRequest"
+            }
+          }
+        },
+        "required": true
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaygroundSettingsResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ]
+    }
+  },
+  "/api/v1/playground-settings/{playground_settings_id}": {
+    "patch": {
+      "tags": [
+        "playground-settings"
+      ],
+      "summary": "Update Playground Settings",
+      "description": "Update playground settings.",
+      "operationId": "update_playground_settings_api_v1_playground_settings__playground_settings_id__patch",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "playground_settings_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Playground Settings Id"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PlaygroundSettingsUpdateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaygroundSettingsResponse"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "tags": [
+        "playground-settings"
+      ],
+      "summary": "Delete Playground Settings",
+      "description": "Delete playground settings.",
+      "operationId": "delete_playground_settings_api_v1_playground_settings__playground_settings_id__delete",
+      "security": [
+        {
+          "API Key": []
+        },
+        {
+          "Tenant ID": []
+        },
+        {
+          "Bearer Auth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "playground_settings_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "title": "Playground Settings Id"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/api-specs/langsmith/playground-settings-response.json
+++ b/reference/api-specs/langsmith/playground-settings-response.json
@@ -1,0 +1,64 @@
+{
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "title": "Id"
+    },
+    "settings": {
+      "additionalProperties": true,
+      "type": "object",
+      "title": "Settings"
+    },
+    "options": {
+      "anyOf": [
+        {
+          "$ref": "#/components/schemas/PlaygroundSavedOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Name"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Created At"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Updated At"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Description"
+    }
+  },
+  "type": "object",
+  "required": [
+    "id",
+    "settings",
+    "created_at",
+    "updated_at"
+  ],
+  "title": "PlaygroundSettingsResponse"
+}

--- a/reference/api-specs/langsmith/playground-settings-update-request.json
+++ b/reference/api-specs/langsmith/playground-settings-update-request.json
@@ -1,0 +1,50 @@
+{
+  "properties": {
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Name"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Description"
+    },
+    "settings": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Settings"
+    },
+    "options": {
+      "anyOf": [
+        {
+          "$ref": "#/components/schemas/PlaygroundSavedOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "title": "PlaygroundSettingsUpdateRequest"
+}

--- a/reference/research/461-openapi-validation.md
+++ b/reference/research/461-openapi-validation.md
@@ -1,0 +1,254 @@
+# Playground Settings OpenAPI Validation Report
+
+**Issue**: #473 (Phase 3 of #461)
+**Date**: 2025-12-01
+**Status**: Complete
+
+## Executive Summary
+
+**Validation Result**: Spec matches scout findings with no discrepancies.
+
+The OpenAPI specification for playground-settings endpoints is complete and consistent with the API responses observed during scout research. All endpoints and schemas are well-documented, making SDK implementation straightforward.
+
+## 1. Endpoints Validation
+
+### OpenAPI Spec vs Scout Findings
+
+| Endpoint | Method | OpenAPI | Scout | Match |
+|----------|--------|---------|-------|-------|
+| `/api/v1/playground-settings` | GET | `list_playground_settings_api_v1_playground_settings_get` | List all settings | ✅ |
+| `/api/v1/playground-settings` | POST | `create_playground_settings_api_v1_playground_settings_post` | Create new settings | ✅ |
+| `/api/v1/playground-settings/{playground_settings_id}` | PATCH | `update_playground_settings_api_v1_playground_settings__playground_settings_id__patch` | Update existing | ✅ |
+| `/api/v1/playground-settings/{playground_settings_id}` | DELETE | `delete_playground_settings_api_v1_playground_settings__playground_settings_id__delete` | Delete settings | ✅ |
+
+**Note**: No dedicated GET-by-ID endpoint exists. Single items must be filtered from list results.
+
+### Authentication
+
+All endpoints support the same authentication methods:
+- API Key
+- Tenant ID
+- Bearer Auth
+
+## 2. Schema Validation
+
+### PlaygroundSettingsResponse
+
+**OpenAPI Schema** (from `playground-settings-response.json`):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | string (uuid) | ✅ Yes | UUID format |
+| `settings` | object | ✅ Yes | `additionalProperties: true` |
+| `options` | PlaygroundSavedOptions \| null | No | Rate limiting config |
+| `name` | string \| null | No | Display name |
+| `description` | string \| null | No | User description |
+| `created_at` | string (date-time) | ✅ Yes | ISO 8601 |
+| `updated_at` | string (date-time) | ✅ Yes | ISO 8601 |
+
+**Sample Data Validation** (from `453-ls-langsmith-model-providers-playground-settings.json`):
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000001",  // ✅ UUID format
+  "settings": { /* object */ },                   // ✅ Object
+  "options": { "requests_per_second": null },     // ✅ PlaygroundSavedOptions
+  "name": "Claude-3-5-sonnet-v2",                 // ✅ String
+  "description": "",                              // ✅ String (empty allowed)
+  "created_at": "2024-01-01T00:00:00.000000",    // ✅ ISO datetime
+  "updated_at": "2024-01-01T00:00:00.000000"     // ✅ ISO datetime
+}
+```
+
+**Result**: ✅ All sample responses match schema
+
+### PlaygroundSettingsCreateRequest
+
+**OpenAPI Schema** (from `playground-settings-create-request.json`):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `settings` | object | ✅ Yes | LangChain serialized model config |
+| `name` | string \| null | No | Optional display name |
+| `description` | string \| null | No | Optional description |
+| `options` | PlaygroundSavedOptions \| null | No | Rate limiting |
+
+**Key Finding**: Only `settings` is required for creation.
+
+### PlaygroundSettingsUpdateRequest
+
+**OpenAPI Schema** (from `playground-settings-update-request.json`):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string \| null | No | Update name |
+| `description` | string \| null | No | Update description |
+| `settings` | object \| null | No | Update model config |
+| `options` | PlaygroundSavedOptions \| null | No | Update rate limiting |
+
+**Key Finding**: All fields optional - supports partial updates via PATCH.
+
+### PlaygroundSavedOptions
+
+**OpenAPI Schema** (from `playground-saved-options.json`):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `requests_per_second` | integer \| null | No | Rate limit (optional) |
+
+**Sample Data Validation**:
+- 8 of 9 samples: `"requests_per_second": null` ✅
+- 1 sample (id=...000006): `"requests_per_second": 25` ✅
+
+## 3. Settings Object Structure
+
+The `settings` field is defined as `additionalProperties: true` (generic object). Analysis of sample data reveals the LangChain serialization format:
+
+### Structure
+
+```json
+{
+  "id": ["langchain", "chat_models", "<provider>", "<class>"],
+  "lc": 1,
+  "type": "constructor",
+  "kwargs": { /* provider-specific parameters */ }
+}
+```
+
+### Provider ID Paths (from sample data)
+
+| Provider | ID Path |
+|----------|---------|
+| Anthropic | `["langchain", "chat_models", "anthropic", "ChatAnthropic"]` |
+| OpenAI | `["langchain", "chat_models", "openai", "ChatOpenAI"]` |
+| Azure OpenAI | `["langchain", "chat_models", "azure_openai", "AzureChatOpenAI"]` |
+| AWS Bedrock (Converse) | `["langchain_aws", "chat_models", "ChatBedrockConverse"]` |
+| AWS Bedrock (Legacy) | `["langchain", "chat_models", "bedrock", "ChatBedrock"]` |
+
+### Secret References
+
+API keys are stored as references, not values:
+
+```json
+{
+  "anthropic_api_key": {
+    "id": ["ANTHROPIC_API_KEY"],
+    "lc": 1,
+    "type": "secret"
+  }
+}
+```
+
+**Note**: The OpenAPI spec does NOT define the internal structure of `settings`. This is by design - the structure is determined by LangChain serialization conventions.
+
+## 4. Discrepancies
+
+**None found.** The OpenAPI specification accurately describes the API behavior observed in scout research.
+
+### Minor Observations
+
+1. **No GET-by-ID endpoint**: The spec only defines list (GET /) and CRUD operations. To fetch a single setting by ID, clients must filter from the list or construct the path manually.
+
+2. **Path parameter naming**: The spec uses `playground_settings_id` as the path parameter name, which is verbose but explicit.
+
+3. **Response for DELETE**: Returns empty schema `{}` on success (204-style response with 200 status).
+
+## 5. SDK Implementation Notes
+
+Based on this validation:
+
+### Rust Type Mapping
+
+| OpenAPI Type | Rust Type |
+|--------------|-----------|
+| `string (uuid)` | `uuid::Uuid` |
+| `string (date-time)` | `chrono::DateTime<Utc>` |
+| `string \| null` | `Option<String>` |
+| `integer \| null` | `Option<i64>` |
+| `object (additionalProperties)` | `serde_json::Value` |
+
+### Recommended struct definitions
+
+```rust
+// Response type
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlaygroundSettings {
+    pub id: Uuid,
+    pub settings: Value,
+    #[serde(default)]
+    pub options: Option<PlaygroundSavedOptions>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// Options type
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PlaygroundSavedOptions {
+    pub requests_per_second: Option<i64>,
+}
+
+// Create request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlaygroundSettingsCreate {
+    pub settings: Value,  // Required
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<PlaygroundSavedOptions>,
+}
+
+// Update request (all fields optional)
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PlaygroundSettingsUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<PlaygroundSavedOptions>,
+}
+```
+
+## 6. Extracted Fragments
+
+The following OpenAPI fragments were extracted and added to `reference/api-specs/langsmith/`:
+
+| File | Size | Content |
+|------|------|---------|
+| `playground-settings-endpoints.json` | 4.9K | Full endpoint definitions |
+| `playground-settings-response.json` | 1.1K | Response schema |
+| `playground-settings-create-request.json` | 0.8K | Create request schema |
+| `playground-settings-update-request.json` | 0.8K | Update request schema |
+| `playground-saved-options.json` | 0.3K | Options sub-schema |
+
+**jq extraction commands** added to `reference/api-specs/langsmith/FRAGMENTS.md`.
+
+## 7. Conclusion
+
+The playground-settings API is well-documented and ready for SDK implementation:
+
+1. **Complete CRUD support**: All operations are available and documented
+2. **Consistent patterns**: Follows LangSmith API conventions
+3. **Flexible settings**: Generic object allows any LangChain model configuration
+4. **Clear authentication**: Standard LangSmith auth methods
+
+### Recommended Next Steps
+
+1. Proceed with SDK Phase (Phase 4: SDK List implementation)
+2. Use extracted schemas as reference for type definitions
+3. Consider adding provider-specific helper types in future phases
+
+## References
+
+- Scout Report: `docs/research/453-ls-langsmith-model-providers-scout.md`
+- Design Decisions: `docs/research/461-model-providers-design.md`
+- SDK Patterns: `reference/repo/langchain-ai/langsmith-sdk/notes/playground-settings-patterns.md`
+- Sample Data: `reference/research/453-ls-langsmith-model-providers-playground-settings.json`
+- OpenAPI Spec: `reference/openapi/langchain/langsmith/openapi.json`
+- Extracted Fragments: `reference/api-specs/langsmith/playground-settings-*.json`


### PR DESCRIPTION
## Summary

Fixes #473

Phase 3 of the ls-langsmith-model-providers milestone (#461). Extracts and validates OpenAPI schemas for the playground-settings API endpoints.

### Changes
- Extracted 5 OpenAPI schema fragments to `reference/api-specs/langsmith/`:
  - `playground-settings-endpoints.json` (4.9K) - Full CRUD endpoints
  - `playground-settings-response.json` (1.1K) - Response schema
  - `playground-settings-create-request.json` (0.8K) - Create request schema
  - `playground-settings-update-request.json` (0.8K) - Update request schema
  - `playground-saved-options.json` (0.3K) - Options sub-schema
- Updated `FRAGMENTS.md` with jq extraction queries
- Created validation report at `reference/research/461-openapi-validation.md`

### Validation Results

**No discrepancies found** between OpenAPI spec and scout findings:
- All 4 endpoints (GET list, POST create, PATCH update, DELETE) documented
- Response schema matches sample data structure
- Settings field correctly defined as generic object (LangChain serialization format)
- PlaygroundSavedOptions schema with optional `requests_per_second`

### Next Steps

Ready for SDK implementation (Phase 4: SDK List method).

## Test plan

- [x] Verified all jq extraction queries produce valid JSON
- [x] Compared extracted schemas against sample API responses
- [x] Validated FRAGMENTS.md table entries match file sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)