### PR TITLE
📚 docs: research SDK precedent for workspace secrets

### DIFF
--- a/docs/research/484.1-ls-secrets-sdk-precedent.md
+++ b/docs/research/484.1-ls-secrets-sdk-precedent.md
@@ -484,7 +484,8 @@ impl LangchainClient {
     /// # Example
     ///
     /// ```no_run
-    /// # use langstar_sdk::{AuthConfig, LangchainClient, SecretUpsert};
+    /// # use langstar_sdk::{AuthConfig, LangchainClient};
+    /// # use langstar_sdk::secrets::SecretUpsert;
     /// # async fn example() -> langstar_sdk::Result<()> {
     /// let auth = AuthConfig::from_env()?;
     /// let client = LangchainClient::new(auth)?;
@@ -515,6 +516,7 @@ impl LangchainClient {
         let request_builder = self
             .langsmith_post("/api/v1/workspaces/current/secrets")?
             .json(&secrets);
+        // API returns empty object {} or null (per scout #456)
         self.execute_status_only_request(request_builder).await
     }
 
@@ -583,11 +585,11 @@ impl LangchainClient {
 
 | Aspect | Datasets (Standard CRUD) | Secrets (Upsert Pattern) |
 |--------|-------------------------|-------------------------|
-| **Create** | `POST /datasets` → Dataset | `POST /secrets` → void |
-| **List** | `GET /datasets` → Dataset[] | `GET /secrets` → SecretKey[] |
-| **Get by ID** | `GET /datasets/{id}` → Dataset | ❌ Not supported (security) |
-| **Update** | `PATCH /datasets/{id}` → Dataset | `POST /secrets` (upsert) |
-| **Delete** | `DELETE /datasets/{id}` → void | `POST /secrets` (value: null) |
+| **Create** | `POST /api/v1/datasets` → Dataset | `POST /api/v1/workspaces/current/secrets` → void |
+| **List** | `GET /api/v1/datasets` → Dataset[] | `GET /api/v1/workspaces/current/secrets` → SecretKey[] |
+| **Get by ID** | `GET /api/v1/datasets/{id}` → Dataset | ❌ Not supported (security) |
+| **Update** | `PATCH /api/v1/datasets/{id}` → Dataset | `POST /api/v1/workspaces/current/secrets` (upsert) |
+| **Delete** | `DELETE /api/v1/datasets/{id}` → void | `POST /api/v1/workspaces/current/secrets` (value: null) |
 | **Batch ops** | One at a time | Array support built-in |
 | **Response** | Full object with data | Keys only (no values) |
 | **Permissions** | Standard API key | Needs `workspaces:manage` for writes |
@@ -705,7 +707,7 @@ mod tests {
         let upsert = SecretUpsert::delete("KEY");
         let json = serde_json::to_string(&upsert).unwrap();
         assert!(json.contains(r#""key":"KEY""#));
-        assert!(json.contains(r#""value":null"#) || !json.contains("value"));
+        assert!(!json.contains("value"));
     }
 }
 ```


### PR DESCRIPTION
## Summary

Researches existing SDK implementation patterns in Langstar to ensure consistency when implementing the workspace secrets SDK (Phase 1 of #484).

## Changes

- Created comprehensive research report: `docs/research/484.1-ls-secrets-sdk-precedent.md`
- Analyzed type definition patterns from datasets, deployments, and organization modules
- Documented client method signatures for CRUD operations
- Identified secrets-specific patterns (upsert, security considerations, permissions)
- Provided recommended type definitions and client methods for secrets SDK

## Key Findings

1. **Upsert Pattern**: Secrets API uses POST for both create and update (not traditional CRUD)
2. **Security First**: API returns only keys, never values
3. **Permission Requirements**: Write operations require `workspaces:manage` permission
4. **Batch Support**: API designed for array inputs (multiple secrets at once)
5. **No GET by Key**: Individual secret retrieval not supported (security)

## Related Issues

Fixes #487

Part of milestone: ls-secrets (#484)

## Test Plan

- [x] Research report documents all necessary patterns
- [x] Includes code examples for recommended implementations
- [x] References all relevant source files and line numbers
- [x] Compares secrets patterns with existing resource patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)