### PR TITLE
🩹 fix(ci): remove stderr redirection in cleanup-test-deployments workflow

### DIFF
--- a/.github/workflows/cleanup-test-deployments.yml
+++ b/.github/workflows/cleanup-test-deployments.yml
@@ -55,7 +55,7 @@ jobs:
           # Get test deployments as JSON with error handling, excluding cli-test-deployment-* deployments
           if ! raw_deployments=$(./target/release/langstar graph list \
             --name-contains "test-deployment-" \
-            --format json 2>&1); then
+            --format json); then
             echo "❌ Error: Failed to list deployments"
             echo "$raw_deployments"
             exit 1


### PR DESCRIPTION
Fixes #511

## Summary

Removes the `2>&1` stderr redirection on line 58 of the `cleanup-test-deployments.yml` workflow file that was causing jq parsing failures.

## Root Cause

The `langstar graph list --format json` command correctly follows Unix conventions by:
- Outputting informational messages (like "ℹ Fetching deployments...") to **stderr**
- Outputting JSON data to **stdout**

The `2>&1` redirection was mixing both streams, causing the captured `raw_deployments` variable to contain:
```
ℹ Fetching deployments (limit: 20, offset: 0)...
{"resources":[...],"offset":0}
```

When piped to `jq`, it failed with "Invalid numeric literal at line 1, column 4" because the first line wasn't valid JSON.

## Solution

Removed the `2>&1` redirection so:
- Only stdout (the JSON) is captured in the variable
- Stderr messages still appear in workflow logs for debugging
- The JSON variable contains only valid JSON for jq to parse

## Changes

- `.github/workflows/cleanup-test-deployments.yml:58` - Removed ` 2>&1` from command substitution

## Test Plan

- [x] Verified the fix by reviewing the code change
- [x] Ran pre-commit checks (fmt, check, clippy, test)
- [ ] Workflow will be tested when merged to main and triggered by schedule or manual dispatch

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>