### PR TITLE
📚 docs(projects): add CLI design decisions for DX consistency

### DIFF
--- a/reference/research/588-ls-projects-precedent.md
+++ b/reference/research/588-ls-projects-precedent.md
@@ -894,10 +894,11 @@ pub output: OutputFormat,
 ```
 
 **Rationale**:
-1. **Extensibility**: Supports future formats (YAML, CSV, text) without breaking changes
+1. **Extensibility**: Supports future formats (text, records) without breaking changes
 2. **Explicitness**: Users can request `--output table` or `--output json` explicitly
 3. **Consistency**: One pattern across the entire CLI
-4. **User Expectations**: `-o/--output` is standard (see `cargo build -o`, `gcc -o`)
+4. **Research-backed**: CLI output research (#581, PR #583) evaluated precedents (gh, kubectl, aws) and explicitly recommended `-o/--output` pattern over alternatives
+5. **Ecosystem alignment**: Matches kubectl `-o`, AWS CLI `--output`, standard CLI conventions
 
 **FILES REQUIRING CHANGE**:
 - `cli/src/commands/dataset.rs:61-62, 85-86, 96-97, 115-116` - Replace `pub json: bool` with `pub output: OutputFormat`


### PR DESCRIPTION
## Summary

Completes Phase 2 design work for the ls-projects milestone by adding comprehensive CLI design decisions to the Phase 1 research report.

## Changes

Added **Section 9: CLI Design Decisions** to `reference/research/588-ls-projects-precedent.md` with:

### 9.1 Design Analysis
Analyzed existing CLI patterns across datasets, queues, and runs commands and identified three critical inconsistencies:

1. **`--limit` type mismatch**: datasets use `i64`, queues use `u32`, runs use `usize`
2. **Output format divergence**: datasets/queues use `--json` bool, runs use `-o/--output` enum
3. **Destructive operation flags**: datasets use `--yes/-y`, queues use `--force`

### 9.2 Finalized Design Specifications
Complete, implementation-ready specifications for all 5 project commands:
- `list` - with `--name`, `--name-contains`, `--limit`, `--include-stats`, `-o/--output`
- `get` - with flexible identifier (name OR UUID), `--include-stats`, `-o/--output`
- `create` - with `--name`, `--description`, `--metadata`, `-o/--output`
- `update` - with flexible identifier, optional fields, `-o/--output`
- `delete` - with flexible identifier, `--force/-f` safety flag

### 9.3-9.6 Additional Documentation
- Breaking changes analysis (for future retrofitting of old commands)
- Implementation phases and recommendations
- Clear rationale for each design decision

## Key Design Decisions

**✅ Use `-o/--output` with `OutputFormat` enum**
- More extensible than `--json` boolean
- Aligns with ls-cli-output-dx milestone direction (#529)
- Runs command already uses this pattern
- Future-proof for text/records formats

**✅ Accept both name and UUID identifiers**
- Users remember names, not UUIDs
- Python SDK supports both patterns
- Implement `ProjectIdentifier` enum in SDK

**✅ Use `--force/-f` for destructive operations**
- Clearer danger signal than `--yes`
- Unix convention (`rm -f`, `git push --force`)
- Consistent with other system tools

**✅ Standardize `--limit` to `u32` type**
- Pagination limits cannot be negative
- More portable than `usize`

## Files Referenced

All recommendations include specific file paths and line numbers for implementation:
- `cli/src/commands/dataset.rs` - multiple locations documented
- `cli/src/commands/queue.rs` - multiple locations documented
- `cli/src/commands/runs.rs:127` - limit type
- New: `cli/src/commands/project.rs` - to be created
- New: `sdk/src/projects.rs` - to be created

## Related Issues

- Fixes #590 (this design phase)
- Parent: #586 (ls-projects Phase 2)
- Epic: #15 (ls-projects milestone)
- Related: #529 (ls-cli-output-dx milestone)

## Test Plan

- [x] All design specifications documented
- [x] File references include specific line numbers
- [x] Rationale provided for each decision
- [x] Ready for implementation in next phase

## Next Steps

Phase 3 (OpenAPI validation) and Phase 4 (SDK implementation) can now proceed using Section 9.2 as the specification.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)