### PR TITLE
♻️ refactor(cli): implement pagination for deployment resolution

### DIFF
--- a/cli/src/deployment_utils.rs
+++ b/cli/src/deployment_utils.rs
@@ -33,12 +33,27 @@ pub async fn resolve_deployment_url(
     );
     let client = LangchainClient::new(auth)?;
 
-    // List deployments (limit 100 to catch most cases)
-    let deployments_list = client.deployments().list(Some(100), Some(0), None).await?;
+    // List all deployments with pagination
+    let page_size = 100;
+    let mut offset = 0;
+    let mut all_deployments = Vec::new();
+
+    loop {
+        let deployments_list = client
+            .deployments()
+            .list(Some(page_size), Some(offset), None)
+            .await?;
+        let count = deployments_list.resources.len();
+        all_deployments.extend(deployments_list.resources);
+
+        if count < page_size as usize {
+            break;
+        }
+        offset += page_size;
+    }
 
     // Find deployment by name or ID
-    let deployment = deployments_list
-        .resources
+    let deployment = all_deployments
         .iter()
         .find(|d| d.name == deployment_name_or_id || d.id == deployment_name_or_id)
         .ok_or_else(|| {


### PR DESCRIPTION
## Summary
- Implement pagination for `resolve_deployment_url()` to handle workspaces with more than 100 deployments

## Changes
- Added pagination loop in `cli/src/deployment_utils.rs`
- Pages through all deployments instead of only first 100

## Related Issues
Fixes #628

## Test Plan
- [x] Existing tests pass
- [x] Code compiles without warnings

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>