### PR TITLE
♻️ refactor(auth): consolidate to single LANGSMITH_API_KEY

### DIFF
--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -89,14 +89,6 @@ impl ConfigCommands {
                 "not configured"
             }
         );
-        println!(
-            "  LangGraph API key: {}",
-            if config.langgraph_api_key.is_some() {
-                "configured"
-            } else {
-                "not configured"
-            }
-        );
 
         // Show scoping configuration
         println!("\nScoping configuration:");
@@ -140,14 +132,6 @@ impl ConfigCommands {
         println!(
             "  LANGSMITH_WORKSPACE_ID: {}",
             std::env::var("LANGSMITH_WORKSPACE_ID").unwrap_or_else(|_| "not set".to_string())
-        );
-        println!(
-            "  LANGGRAPH_API_KEY: {}",
-            if std::env::var("LANGGRAPH_API_KEY").is_ok() {
-                "set"
-            } else {
-                "not set"
-            }
         );
         println!(
             "  LANGSTAR_OUTPUT_FORMAT: {}",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -6,10 +6,8 @@ use std::path::PathBuf;
 /// Configuration for the Langstar CLI
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    /// LangSmith API key
+    /// LangSmith API key (used for both LangSmith and LangGraph APIs)
     pub langsmith_api_key: Option<String>,
-    /// LangGraph Cloud API key
-    pub langgraph_api_key: Option<String>,
     /// Optional organization ID for scoping LangSmith operations
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organization_id: Option<String>,
@@ -45,7 +43,6 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             langsmith_api_key: None,
-            langgraph_api_key: None,
             organization_id: None,
             workspace_id: None,
             github_integration_id: None,
@@ -70,9 +67,6 @@ impl Config {
         // Override with environment variables
         if let Ok(key) = std::env::var("LANGSMITH_API_KEY") {
             config.langsmith_api_key = Some(key);
-        }
-        if let Ok(key) = std::env::var("LANGGRAPH_API_KEY") {
-            config.langgraph_api_key = Some(key);
         }
         if let Ok(org_id) = std::env::var("LANGSMITH_ORGANIZATION_ID") {
             config.organization_id = Some(org_id);
@@ -156,7 +150,6 @@ impl Config {
     pub fn to_auth_config(&self) -> AuthConfig {
         AuthConfig::new(
             self.langsmith_api_key.clone(),
-            self.langgraph_api_key.clone(),
             self.organization_id.clone(),
             self.workspace_id.clone(),
         )
@@ -173,14 +166,12 @@ mod tests {
         assert_eq!(config.output_format, "table");
         assert_eq!(config.timezone, "local");
         assert!(config.langsmith_api_key.is_none());
-        assert!(config.langgraph_api_key.is_none());
     }
 
     #[test]
     fn test_config_serialization() {
         let config = Config {
             langsmith_api_key: Some("test_key".to_string()),
-            langgraph_api_key: None,
             organization_id: Some("test_org_id".to_string()),
             workspace_id: None,
             github_integration_id: None,
@@ -202,7 +193,6 @@ mod tests {
     fn test_config_with_workspace() {
         let config = Config {
             langsmith_api_key: Some("test_key".to_string()),
-            langgraph_api_key: None,
             organization_id: None,
             workspace_id: Some("test_workspace_id".to_string()),
             github_integration_id: None,
@@ -220,7 +210,6 @@ mod tests {
     fn test_config_to_auth_config_with_both() {
         let config = Config {
             langsmith_api_key: Some("key".to_string()),
-            langgraph_api_key: None,
             organization_id: Some("org_123".to_string()),
             workspace_id: Some("workspace_456".to_string()),
             github_integration_id: None,

--- a/cli/src/deployment_utils.rs
+++ b/cli/src/deployment_utils.rs
@@ -28,7 +28,6 @@ pub async fn resolve_deployment_url(
     let auth = AuthConfig::new(
         config.langsmith_api_key.clone(),
         None,
-        None,
         config.workspace_id.clone(),
     );
     let client = LangchainClient::new(auth)?;

--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -4,10 +4,8 @@ use std::env;
 /// Authentication configuration for LangChain services
 #[derive(Debug, Clone)]
 pub struct AuthConfig {
-    /// LangSmith API key
+    /// LangSmith API key (used for both LangSmith and LangGraph APIs)
     pub langsmith_api_key: Option<String>,
-    /// LangGraph Cloud API key
-    pub langgraph_api_key: Option<String>,
     /// Optional organization ID for scoping API requests
     pub organization_id: Option<String>,
     /// Optional workspace ID for narrower scoping of API requests
@@ -18,14 +16,12 @@ impl AuthConfig {
     /// Create a new AuthConfig by loading from environment variables
     ///
     /// Loads the following environment variables:
-    /// - `LANGSMITH_API_KEY` - LangSmith API key
-    /// - `LANGGRAPH_API_KEY` - LangGraph Cloud API key
+    /// - `LANGSMITH_API_KEY` - API key for LangSmith and LangGraph APIs
     /// - `LANGSMITH_ORGANIZATION_ID` - Optional organization ID for scoping
     /// - `LANGSMITH_WORKSPACE_ID` - Optional workspace ID for narrower scoping
     pub fn from_env() -> Result<Self> {
         Ok(Self {
             langsmith_api_key: env::var("LANGSMITH_API_KEY").ok(),
-            langgraph_api_key: env::var("LANGGRAPH_API_KEY").ok(),
             organization_id: env::var("LANGSMITH_ORGANIZATION_ID").ok(),
             workspace_id: env::var("LANGSMITH_WORKSPACE_ID").ok(),
         })
@@ -34,33 +30,23 @@ impl AuthConfig {
     /// Create a new AuthConfig with explicit values
     pub fn new(
         langsmith_api_key: Option<String>,
-        langgraph_api_key: Option<String>,
         organization_id: Option<String>,
         workspace_id: Option<String>,
     ) -> Self {
         Self {
             langsmith_api_key,
-            langgraph_api_key,
             organization_id,
             workspace_id,
         }
     }
 
     /// Get LangSmith API key, returning error if not configured
+    ///
+    /// This key is used for both LangSmith and LangGraph API calls.
     pub fn require_langsmith_key(&self) -> Result<&str> {
         self.langsmith_api_key.as_deref().ok_or_else(|| {
             LangstarError::AuthError(
                 "LANGSMITH_API_KEY not configured. Set it via environment variable or config file."
-                    .to_string(),
-            )
-        })
-    }
-
-    /// Get LangGraph API key, returning error if not configured
-    pub fn require_langgraph_key(&self) -> Result<&str> {
-        self.langgraph_api_key.as_deref().ok_or_else(|| {
-            LangstarError::AuthError(
-                "LANGGRAPH_API_KEY not configured. Set it via environment variable or config file."
                     .to_string(),
             )
         })
@@ -75,7 +61,6 @@ mod tests {
     fn test_auth_config_new() {
         let config = AuthConfig::new(
             Some("test_langsmith_key".to_string()),
-            Some("test_langgraph_key".to_string()),
             Some("test_org_id".to_string()),
             Some("test_workspace_id".to_string()),
         );
@@ -83,26 +68,20 @@ mod tests {
             config.require_langsmith_key().unwrap(),
             "test_langsmith_key"
         );
-        assert_eq!(
-            config.require_langgraph_key().unwrap(),
-            "test_langgraph_key"
-        );
         assert_eq!(config.organization_id.as_deref().unwrap(), "test_org_id");
         assert_eq!(config.workspace_id.as_deref().unwrap(), "test_workspace_id");
     }
 
     #[test]
     fn test_auth_config_missing_key() {
-        let config = AuthConfig::new(None, None, None, None);
+        let config = AuthConfig::new(None, None, None);
         assert!(config.require_langsmith_key().is_err());
-        assert!(config.require_langgraph_key().is_err());
     }
 
     #[test]
     fn test_auth_config_with_org_only() {
         let config = AuthConfig::new(
             Some("test_key".to_string()),
-            None,
             Some("org_123".to_string()),
             None,
         );
@@ -114,7 +93,6 @@ mod tests {
     fn test_auth_config_with_workspace_only() {
         let config = AuthConfig::new(
             Some("test_key".to_string()),
-            None,
             None,
             Some("workspace_456".to_string()),
         );


### PR DESCRIPTION
## Summary
Consolidates authentication to use only `LANGSMITH_API_KEY` for all API calls (both LangSmith and LangGraph).

Fixes #630

## Changes
- **sdk/src/auth.rs**: Remove `langgraph_api_key` field and `require_langgraph_key()` method
- **cli/src/config.rs**: Remove `langgraph_api_key` field and env loading
- **cli/src/commands/config.rs**: Remove LANGGRAPH_API_KEY display sections
- **cli/src/deployment_utils.rs**: Update `AuthConfig::new()` call signature

## Breaking Change
`LANGGRAPH_API_KEY` environment variable is no longer supported. Use `LANGSMITH_API_KEY` for all LangChain/LangGraph API calls.

## Test Plan
- [x] `cargo fmt && cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)