### PR TITLE
🔧 build(ci): ensure CI runs on prepare-release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,12 @@ jobs:
 
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # Get list of changed files in PR
-            CHANGED_FILES=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
+            CHANGED_FILES=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path' 2>/dev/null || echo "")
+            if [ -z "$CHANGED_FILES" ]; then
+              echo "Warning: Could not fetch changed files, running CI as a precaution"
+              echo "should_run=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
 
             # Check if any files outside the ignore patterns changed
             NON_DOCS_CHANGED=false
@@ -65,7 +70,7 @@ jobs:
               # Skip if file matches ignore patterns
               if [[ "$file" == *.md ]] || \
                  [[ "$file" == docs/* ]] || \
-                 [[ "$file" == *.txt && "$file" != */* ]] || \
+                 [[ "$file" == *.txt && ! "$file" =~ / ]] || \
                  [[ "$file" == ".gitignore" ]]; then
                 continue
               fi
@@ -74,7 +79,7 @@ jobs:
               break
             done <<< "$CHANGED_FILES"
 
-            if [ "$NON_DOCS_CHANGED" = "true" ]; then
+            if [[ "$NON_DOCS_CHANGED" == "true" ]]; then
               echo "Code files changed - running CI"
               echo "should_run=true" >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
## Summary

Fixes #640

Modifies the CI workflow to always run on release branches (`release/v*`) created by the prepare-release workflow, even when only documentation or changelog files are modified.

This resolves the issue where the Release workflow's `verify-ci` job fails because it expects CI checks (Check, Test, Clippy, Build) to have run, but they were skipped due to `paths-ignore` filters.

## Changes

### Workflow-Level Changes
- **Removed `paths-ignore` filters** from workflow-level triggers (previously at lines 8-12, 16-22)
- Replaced with job-level conditional execution for more fine-grained control

### New `changes` Job
Added a new job that determines whether to run CI based on:
1. **Branch name pattern**: Always runs CI for `release/*` branches (created by prepare-release workflow)
2. **Changed files**: For regular PRs, skips CI if only these files changed:
   - `**/*.md` (markdown files)
   - `docs/**` (documentation directory)
   - `*.txt` (root-level text files)
   - `.gitignore`
3. **Push events**: Always runs CI for pushes to main

### Job Dependencies
- All CI jobs now depend on the `changes` job
- Jobs run conditionally: `if: needs.changes.outputs.should_run == 'true'`
- Updated `all-jobs` aggregator to include `changes` in its needs list

## Implementation Details

The `changes` job (`lines 29-90`):
- Detects release branches using pattern matching: `release/*`
- For PRs, uses `gh pr view` to get changed files and filters them
- Sets output `should_run` to `true`/`false` based on the checks above

All downstream jobs check `needs.changes.outputs.should_run == 'true'` before running.

## Why This Approach?

**Alternative approaches considered:**
1. ❌ **`pull_request_target`**: Security implications (runs in base branch context)
2. ❌ **Multiple workflow triggers**: GitHub Actions merges multiple `pull_request` entries
3. ❌ **Workflow-level conditionals**: Can't access PR metadata if workflow is filtered out by `paths-ignore`

✅ **Job-level conditionals**: Allows workflow to run, then conditionally execute jobs based on branch and file changes.

## Testing

This PR will test the new logic:
- Modified only `.github/workflows/ci.yml`
- Should trigger full CI since it's a code file change
- Once merged, release PRs will trigger CI even with only CHANGELOG.md changes

## References

- **Issue**: #640
- **Failed release workflow**: https://github.com/codekiln/langstar/actions/runs/19992537324
- **prepare-release workflow**: `.github/workflows/prepare-release.yml:241` (branch pattern)
- **Release workflow verify-ci job**: `.github/workflows/release.yml:19-58`

## Test Plan

- [x] YAML syntax validated (via `gh workflow view`)
- [x] Commit follows conventional emoji commits
- [ ] CI runs successfully on this PR (workflow file changed)
- [ ] After merge: Test by creating a release PR with only CHANGELOG.md changes
- [ ] Verify Release workflow succeeds when CI checks are present

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>