### PR TITLE
🩹 fix(sdk): make AnnotationQueue timestamps optional

### DIFF
--- a/cli/src/commands/queue.rs
+++ b/cli/src/commands/queue.rs
@@ -215,7 +215,10 @@ impl From<&AnnotationQueue> for QueueRow {
             name: queue.name.clone(),
             queue_type: format!("{:?}", queue.queue_type).to_lowercase(),
             description,
-            created: queue.created_at.format("%Y-%m-%d").to_string(),
+            created: queue
+                .created_at
+                .map(|dt| dt.format("%Y-%m-%d").to_string())
+                .unwrap_or_else(|| "-".to_string()),
         }
     }
 }
@@ -315,10 +318,9 @@ impl QueueCommands {
             println!("  ID: {}", queue.base.id);
             println!("  Name: {}", queue.base.name);
             println!("  Type: {:?}", queue.base.queue_type);
-            println!(
-                "  Created: {}",
-                queue.base.created_at.format("%Y-%m-%dT%H:%M:%SZ")
-            );
+            if let Some(created_at) = queue.base.created_at {
+                println!("  Created: {}", created_at.format("%Y-%m-%dT%H:%M:%SZ"));
+            }
         }
 
         Ok(())
@@ -342,14 +344,12 @@ impl QueueCommands {
             if let Some(rubric) = &queue.rubric_instructions {
                 println!("  Rubric: {}", rubric);
             }
-            println!(
-                "  Created: {}",
-                queue.base.created_at.format("%Y-%m-%dT%H:%M:%SZ")
-            );
-            println!(
-                "  Updated: {}",
-                queue.base.updated_at.format("%Y-%m-%dT%H:%M:%SZ")
-            );
+            if let Some(created_at) = queue.base.created_at {
+                println!("  Created: {}", created_at.format("%Y-%m-%dT%H:%M:%SZ"));
+            }
+            if let Some(updated_at) = queue.base.updated_at {
+                println!("  Updated: {}", updated_at.format("%Y-%m-%dT%H:%M:%SZ"));
+            }
         }
 
         Ok(())

--- a/sdk/src/annotation_queues.rs
+++ b/sdk/src/annotation_queues.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::serde_utils::{deserialize_flexible_datetime, deserialize_flexible_datetime_opt};
+use crate::serde_utils::deserialize_flexible_datetime_opt;
 
 /// Queue type enum for annotation queues.
 ///
@@ -97,12 +97,12 @@ pub struct AnnotationQueue {
     pub description: Option<String>,
 
     /// When the queue was created
-    #[serde(deserialize_with = "deserialize_flexible_datetime")]
-    pub created_at: DateTime<Utc>,
+    #[serde(default, deserialize_with = "deserialize_flexible_datetime_opt")]
+    pub created_at: Option<DateTime<Utc>>,
 
     /// When the queue was last updated
-    #[serde(deserialize_with = "deserialize_flexible_datetime")]
-    pub updated_at: DateTime<Utc>,
+    #[serde(default, deserialize_with = "deserialize_flexible_datetime_opt")]
+    pub updated_at: Option<DateTime<Utc>>,
 
     /// Number of reviewers required per item (default: 1)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -396,9 +396,29 @@ mod tests {
         let queue: AnnotationQueue = serde_json::from_str(json).unwrap();
         assert_eq!(queue.name, "Review Queue");
         assert_eq!(queue.queue_type, QueueType::Single);
+        assert!(queue.created_at.is_some());
+        assert!(queue.updated_at.is_some());
         assert_eq!(queue.num_reviewers_per_item, Some(2));
         assert_eq!(queue.enable_reservations, Some(true));
         assert_eq!(queue.reservation_minutes, Some(5));
+    }
+
+    #[test]
+    fn test_annotation_queue_deserialization_without_timestamps() {
+        // Test that queues can be deserialized even without created_at/updated_at
+        // This was causing the bug in issue #624
+        let json = r#"{
+            "id": "12345678-1234-1234-1234-123456789012",
+            "name": "Minimal Queue",
+            "tenantId": "87654321-4321-4321-4321-210987654321",
+            "queueType": "single"
+        }"#;
+
+        let queue: AnnotationQueue = serde_json::from_str(json).unwrap();
+        assert_eq!(queue.name, "Minimal Queue");
+        assert_eq!(queue.queue_type, QueueType::Single);
+        assert!(queue.created_at.is_none());
+        assert!(queue.updated_at.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The `langstar queue list` command was failing with "error decoding response body" when attempting to deserialize annotation queues from the LangSmith API.

## Root Cause

The `AnnotationQueue` struct defined `created_at` and `updated_at` as required fields, but according to the OpenAPI spec (`annotation-queue-schemas.json:436-442`), these fields are NOT in the required fields list. The API was returning queues without these timestamp fields, causing deserialization failures.

## Solution

1. Changed `created_at` and `updated_at` from `DateTime<Utc>` to `Option<DateTime<Utc>>`
2. Updated all CLI display code to handle optional timestamps gracefully
3. Added test case to verify deserialization works without timestamps

## Changes

**SDK (`sdk/src/annotation_queues.rs`):**
- Made `AnnotationQueue.created_at` and `updated_at` optional fields
- Updated deserializer to use `deserialize_flexible_datetime_opt`
- Added test case for queues without timestamps

**CLI (`cli/src/commands/queue.rs`):**
- Updated `QueueRow::from()` to handle optional `created_at`
- Updated `execute_create()` to conditionally print `created_at`
- Updated `execute_get()` to conditionally print both timestamps

## Related Issues

Fixes #624

## Test Plan

- [x] All annotation_queues unit tests pass (11/11)
- [x] cargo check --workspace --all-features passes
- [x] cargo clippy --workspace --all-features passes
- [x] cargo fmt passes
- [x] New test verifies deserialization without timestamps works

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>