### PR TITLE
🩹 fix(sdk): replace unconditional #[ignore] with conditional ignores in SDK integration tests

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -37,6 +37,8 @@ serial_test = "3"
 
 [features]
 default = []
+# Feature flag to enable integration tests that require API access
+integration-tests = []
 # Enable test utilities for integration tests
 # Use this feature when you need shared test infrastructure for deployments
 test-utils = []

--- a/sdk/tests/structured_prompts_integration_test.rs
+++ b/sdk/tests/structured_prompts_integration_test.rs
@@ -135,7 +135,7 @@ fn create_test_movie_review_prompt() -> StructuredPrompt {
 }
 
 #[tokio::test]
-#[ignore] // Only run with --ignored flag
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn test_push_structured_prompt_integration() {
     let client = create_integration_test_client().await;
 
@@ -190,7 +190,7 @@ async fn test_push_structured_prompt_integration() {
 }
 
 #[tokio::test]
-#[ignore]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn test_pull_structured_prompt_integration() {
     let client = create_integration_test_client().await;
 
@@ -243,7 +243,7 @@ async fn test_pull_structured_prompt_integration() {
 }
 
 #[tokio::test]
-#[ignore]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn test_structured_prompt_round_trip_integration() {
     let client = create_integration_test_client().await;
 
@@ -300,7 +300,7 @@ async fn test_structured_prompt_round_trip_integration() {
 }
 
 #[tokio::test]
-#[ignore]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn test_push_function_calling_method() {
     let client = create_integration_test_client().await;
 


### PR DESCRIPTION
## Summary
- Fixed 4 SDK integration tests to use conditional `#[cfg_attr]` ignores instead of unconditional `#[ignore]`
- Added `integration-tests` feature flag to SDK's Cargo.toml
- Tests now run when `--features integration-tests` is enabled, but remain ignored in normal test runs

## Changes
- `sdk/Cargo.toml`: Added `integration-tests = []` feature flag (sdk/Cargo.toml:41)
- `sdk/tests/structured_prompts_integration_test.rs`: Updated 4 test functions (lines 138, 193, 246, 303)
  - Replaced `#[ignore] // Only run with --ignored flag`
  - With `#[cfg_attr(not(feature = "integration-tests"), ignore)]`

## Related Issues
Fixes #670

## Test Plan
- [x] Verified tests are ignored without feature flag: `cargo test -p langstar-sdk --test structured_prompts_integration_test` (4 ignored)
- [x] Verified tests run with feature flag: `cargo test --features integration-tests -p langstar-sdk --test structured_prompts_integration_test` (4 tests execute)
- [x] Pre-commit checklist passes: `cargo fmt && cargo check --workspace --all-features && cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace --all-features --lib`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>