### PR TITLE
🧪 test(cli): replace silent skip pattern with explicit .expect() in CLI integration tests

### DIFF
--- a/cli/tests/prompt_structured_test.rs
+++ b/cli/tests/prompt_structured_test.rs
@@ -50,7 +50,8 @@ fn check_env_vars_public_prompts() {
         .expect("LANGSMITH_API_KEY must be set for integration tests");
     std::env::var("LANGSMITH_ORGANIZATION_ID")
         .expect("LANGSMITH_ORGANIZATION_ID must be set for integration tests");
-    // SAFETY: Safe to remove env var in test setup before tests run
+    // SAFETY: Modifying environment variables is unsafe in multi-threaded contexts.
+    // Tests using this function MUST be marked with #[serial] to prevent data races.
     unsafe {
         std::env::remove_var("LANGSMITH_WORKSPACE_ID");
     }
@@ -223,6 +224,7 @@ fn create_temp_invalid_schema_file() -> NamedTempFile {
 
 #[test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[serial]
 fn test_cli_push_private_prompt() {
     check_env_vars_private_prompts();
 
@@ -378,6 +380,7 @@ fn test_cli_push_public_prompt_invalid_method() {
 
 #[test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[serial]
 fn test_cli_push_private_prompt_function_calling_method() {
     check_env_vars_private_prompts();
 
@@ -417,6 +420,7 @@ fn test_cli_push_private_prompt_function_calling_method() {
 
 #[test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[serial]
 fn test_cli_pull_private_prompt() {
     check_env_vars_private_prompts();
 
@@ -461,6 +465,7 @@ fn test_cli_pull_private_prompt() {
 
 #[test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[serial]
 fn test_cli_private_prompt_round_trip() {
     check_env_vars_private_prompts();
 
@@ -531,6 +536,7 @@ fn test_cli_private_prompt_round_trip() {
 
 #[test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[serial]
 fn test_cli_push_private_prompt_json_output() {
     check_env_vars_private_prompts();
 
@@ -587,6 +593,7 @@ fn test_cli_push_private_prompt_json_output() {
 
 #[test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[serial]
 fn test_cli_pull_private_prompt_json_output() {
     check_env_vars_private_prompts();
 


### PR DESCRIPTION
## Summary
- Replaced silent skip pattern with explicit `.expect()` calls in 9 CLI integration tests
- Tests now fail loudly with clear error messages when environment variables are missing
- Removed unused `check_env_vars()` helper function

## Changes
- Updated `cli/tests/prompt_structured_test.rs`:
  - Replaced `check_env_vars()` early returns with explicit `std::env::var().expect()` calls
  - Added explicit panic for `LANGSMITH_WORKSPACE_ID` conflict with clear error message
  - Removed 40 lines of silent skip helper code
  - Applied pattern to all 9 test functions in the file

## Related Issues
Fixes #672

## Test Plan
- [x] All pre-commit checks passed (formatting, clippy, compilation)
- [x] Tests fail loudly when `LANGSMITH_API_KEY` is missing (verified locally)
- [x] Tests fail loudly when `LANGSMITH_ORGANIZATION_ID` is missing (verified locally)
- [x] Tests fail loudly when `LANGSMITH_WORKSPACE_ID` is incorrectly set (verified locally)
- [x] CI properly reports failures instead of silently skipping tests

## Benefits
✅ Tests fail loudly with clear error messages when environment variables are missing
✅ CI properly reports failures instead of silently skipping tests
✅ Follows testing best practices by making requirements explicit
✅ Reduces technical debt by removing silent skip antipattern

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>