### PR TITLE
🩹 fix(ci): add missing LANGSMITH_ORGANIZATION_ID to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Run full lifecycle deployment test
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGSMITH_ORGANIZATION_ID: ${{ secrets.LANGSMITH_ORGANIZATION_ID }}
           LANGSMITH_WORKSPACE_ID: ${{ secrets.LANGSMITH_WORKSPACE_ID }}
         run: |
           cargo test --test integration_deployment_workflow \


### PR DESCRIPTION
Add LANGSMITH_ORGANIZATION_ID environment variable to the pre-release-validation job in the release workflow to match the CI workflow configuration.

According to docs/dev/environment-variables.md and issue #660, all three environment variables (LANGSMITH_API_KEY, LANGSMITH_ORGANIZATION_ID, LANGSMITH_WORKSPACE_ID) are required for integration tests. The CI workflow already has all three, but the release workflow was missing LANGSMITH_ORGANIZATION_ID, causing test failures.

Fixes #706