### PR TITLE
✨ feat: make gh-start-issue auto-implement issues

### DIFF
--- a/.claude/commands/gh-start-issue.md
+++ b/.claude/commands/gh-start-issue.md
@@ -193,6 +193,8 @@ echo ""
 
 **IMPORTANT**: This command does NOT stop after worktree creation. You MUST immediately begin implementing the issue.
 
+**Testing Principle**: Only run checks necessary to validate the types of changes introduced. The bar is higher for critical items like Rust code or YAML configs than it is for documentation in markdown files. Don't waste time running cargo tests when only markdown changed.
+
 After the bash steps above complete:
 
 1. **Update working directory context** - Change your internal context to the worktree path


### PR DESCRIPTION
## Summary

Updates `/gh-start-issue` command to automatically proceed with implementation after worktree creation instead of stopping and waiting for user instruction.

## Problem

The command currently only sets up a worktree and displays issue details, then stops. This creates poor UX where:
1. User runs `/gh-start-issue 123` expecting Claude to start working
2. User adds instruction like "get started in worktree when ready and submit pr when ready"
3. Claude responds "Your worktree is ready" and waits instead of implementing
4. User has to explicitly say "now implement the issue" to get work started

This has happened ~20 times with the same user, indicating a systemic UX problem.

## Changes

- Updated command description to reflect full workflow automation
- Added "Automatic Implementation (Critical)" section with clear instructions to continue implementing after worktree setup
- Added testing principle: "Only run checks necessary to validate the types of changes introduced"
- Added conditional pre-commit checks based on file type (skip cargo for markdown-only changes)
- Added TodoWrite and Edit to allowed-tools list
- Documented that command should NOT stop at "worktree ready"

## Test Plan

- [x] Updated command documentation with clear implementation instructions
- [x] Added testing principle to prevent unnecessary test runs
- [x] Verified changes are markdown-only (no code changes needed)

## Related Issues

Fixes #714

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>