### PR TITLE
✨ feat(assistant): add description field support from Agent Server API

### DIFF
--- a/cli/src/commands/assistant.rs
+++ b/cli/src/commands/assistant.rs
@@ -8,7 +8,13 @@ use serde_json::json;
 use tabled::Tabled;
 
 /// Available columns for assistant list text output
-const ASSISTANT_COLUMNS: &[&str] = &["assistant_id", "name", "graph_id", "created_at"];
+const ASSISTANT_COLUMNS: &[&str] = &[
+    "assistant_id",
+    "name",
+    "graph_id",
+    "description",
+    "created_at",
+];
 
 /// Commands for interacting with LangGraph Assistants
 #[derive(Debug, Subcommand)]
@@ -28,7 +34,7 @@ pub enum AssistantCommands {
         offset: u32,
 
         /// Select specific columns for text output (comma-separated)
-        /// Available: assistant_id, name, graph_id, created_at
+        /// Available: assistant_id, name, graph_id, description, created_at
         #[arg(long, value_delimiter = ',')]
         columns: Option<Vec<String>>,
 
@@ -75,6 +81,10 @@ pub enum AssistantCommands {
         #[arg(short, long)]
         name: String,
 
+        /// Description for the assistant
+        #[arg(short, long)]
+        description: Option<String>,
+
         /// Configuration JSON file path
         #[arg(long)]
         config_file: Option<String>,
@@ -96,6 +106,10 @@ pub enum AssistantCommands {
         /// Updated name
         #[arg(short, long)]
         name: Option<String>,
+
+        /// Updated description
+        #[arg(short, long)]
+        description: Option<String>,
 
         /// Configuration JSON file path
         #[arg(long)]
@@ -175,6 +189,11 @@ impl ColumnMetadata for Assistant {
                 "assistant_id" => self.assistant_id.clone(),
                 "name" => self.name.replace(['\t', '\n'], " "),
                 "graph_id" => self.graph_id.clone(),
+                "description" => self
+                    .description
+                    .clone()
+                    .unwrap_or_default()
+                    .replace(['\t', '\n'], " "),
                 "created_at" => self
                     .created_at
                     .clone()
@@ -326,6 +345,9 @@ impl AssistantCommands {
                     eprintln!("  ID: {}", assistant.assistant_id);
                     eprintln!("  Name: {}", assistant.name);
                     eprintln!("  Graph ID: {}", assistant.graph_id);
+                    if let Some(description) = &assistant.description {
+                        eprintln!("  Description: {}", description);
+                    }
                     if let Some(created) = &assistant.created_at {
                         eprintln!("  Created: {}", created);
                     }
@@ -347,6 +369,7 @@ impl AssistantCommands {
                 deployment: _,
                 graph_id,
                 name,
+                description,
                 config_file,
                 config,
             } => {
@@ -365,6 +388,7 @@ impl AssistantCommands {
                 let request = CreateAssistantRequest {
                     graph_id: graph_id.clone(),
                     name: name.clone(),
+                    description: description.clone(),
                     config: config_value,
                     metadata: None,
                 };
@@ -386,6 +410,7 @@ impl AssistantCommands {
                 deployment: _,
                 assistant_id,
                 name,
+                description,
                 config_file,
                 config,
             } => {
@@ -403,6 +428,7 @@ impl AssistantCommands {
 
                 let request = UpdateAssistantRequest {
                     name: name.clone(),
+                    description: description.clone(),
                     config: config_value,
                     metadata: None,
                 };
@@ -470,6 +496,7 @@ mod tests {
             assistant_id: "very-long-assistant-id-that-should-be-truncated".to_string(),
             graph_id: "graph-123".to_string(),
             name: "Test Assistant".to_string(),
+            description: None,
             config: None,
             metadata: None,
             created_at: Some("2024-01-01T00:00:00Z".to_string()),

--- a/cli/tests/assistant_command_test.rs
+++ b/cli/tests/assistant_command_test.rs
@@ -146,6 +146,236 @@ fn test_assistant_create_basic() {
 
 #[test]
 #[serial] // Uses shared TEST_DEPLOYMENT - must run serially with other shared deployment tests
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_assistant_description_field() {
+    println!("==================================================");
+    println!("Test: Assistant Description Field (CLI)");
+    println!("==================================================\n");
+
+    let (deployment_name, _graph_name) = get_test_deployment();
+    let assistant_name = generate_test_name("cli-test-assistant-desc");
+
+    // Step 1: Create assistant WITH description
+    println!("1. CREATE assistant with --description flag");
+    println!("   Name: {}", assistant_name);
+    let test_description = "This is a test description via CLI";
+    println!("   Description: {}", test_description);
+
+    let mut cmd = langstar_cmd();
+    cmd.args([
+        "assistant",
+        "create",
+        "--deployment",
+        &deployment_name,
+        "--graph-id",
+        "test_graph",
+        "--name",
+        &assistant_name,
+        "--description",
+        test_description,
+        "--format",
+        "json",
+    ]);
+
+    let output = cmd.output().expect("Failed to execute command");
+
+    println!("Exit status: {}", output.status);
+    println!("Stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+    if !output.stderr.is_empty() {
+        println!("Stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    assert!(
+        output.status.success(),
+        "Assistant create with description should succeed"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Extract JSON from output (skip info messages)
+    let json_start = stdout
+        .find('{')
+        .expect("Should contain JSON object in output");
+    let json_str = &stdout[json_start..];
+
+    let json: serde_json::Value = serde_json::from_str(json_str).expect("Should return valid JSON");
+    let assistant_id = json["assistant_id"]
+        .as_str()
+        .expect("Should have assistant_id field");
+
+    // Verify description is in create response
+    assert!(
+        json.get("description").is_some(),
+        "Create response should include description field"
+    );
+    assert_eq!(
+        json["description"].as_str().unwrap_or(""),
+        test_description,
+        "Description in create response should match input"
+    );
+
+    println!("✓ CLI successfully created assistant with description");
+    println!("  Assistant ID: {}", assistant_id);
+    println!(
+        "  Description: {}",
+        json["description"].as_str().unwrap_or("")
+    );
+
+    // Step 2: GET assistant and verify description appears
+    println!("\n2. GET assistant and verify description");
+    let mut cmd = langstar_cmd();
+    cmd.args([
+        "assistant",
+        "get",
+        assistant_id,
+        "--deployment",
+        &deployment_name,
+        "--format",
+        "json",
+    ]);
+
+    let output = cmd.output().expect("Failed to get assistant");
+    assert!(output.status.success(), "Get should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json_start = stdout.find('{').expect("Should contain JSON");
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout[json_start..]).expect("Should return valid JSON");
+
+    assert_eq!(
+        json["assistant_id"].as_str().unwrap(),
+        assistant_id,
+        "Should return same assistant"
+    );
+
+    // Verify description field is present and correct
+    assert!(
+        json.get("description").is_some(),
+        "Get response should include description field"
+    );
+    assert_eq!(
+        json["description"].as_str().unwrap_or(""),
+        test_description,
+        "Description should match what was set"
+    );
+
+    println!("✓ GET shows correct description");
+    println!(
+        "  Description: {}",
+        json["description"].as_str().unwrap_or("")
+    );
+
+    // Step 3: UPDATE description
+    println!("\n3. UPDATE assistant description");
+    let updated_description = "Updated description via CLI";
+    println!("   New description: {}", updated_description);
+
+    let mut cmd = langstar_cmd();
+    cmd.args([
+        "assistant",
+        "update",
+        assistant_id,
+        "--deployment",
+        &deployment_name,
+        "--description",
+        updated_description,
+        "--format",
+        "json",
+    ]);
+
+    let output = cmd.output().expect("Failed to update assistant");
+    assert!(output.status.success(), "Update should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json_start = stdout.find('{').expect("Should contain JSON");
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout[json_start..]).expect("Should return valid JSON");
+
+    // Verify updated description
+    assert!(
+        json.get("description").is_some(),
+        "Update response should include description"
+    );
+    assert_eq!(
+        json["description"].as_str().unwrap_or(""),
+        updated_description,
+        "Description should be updated"
+    );
+
+    println!("✓ UPDATE successfully changed description");
+    println!(
+        "  New description: {}",
+        json["description"].as_str().unwrap_or("")
+    );
+
+    // Step 4: Verify update persisted with another GET
+    println!("\n4. VERIFY description update persisted");
+    let mut cmd = langstar_cmd();
+    cmd.args([
+        "assistant",
+        "get",
+        assistant_id,
+        "--deployment",
+        &deployment_name,
+        "--format",
+        "json",
+    ]);
+
+    let output = cmd.output().expect("Failed to get assistant after update");
+    assert!(output.status.success(), "Get after update should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json_start = stdout.find('{').expect("Should contain JSON");
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout[json_start..]).expect("Should return valid JSON");
+
+    assert_eq!(
+        json["description"].as_str().unwrap_or(""),
+        updated_description,
+        "Updated description should persist"
+    );
+
+    println!("✓ Updated description persisted correctly");
+
+    // Step 5: Test GET output (non-JSON) includes description
+    println!("\n5. VERIFY description appears in text output");
+    let mut cmd = langstar_cmd();
+    cmd.args([
+        "assistant",
+        "get",
+        assistant_id,
+        "--deployment",
+        &deployment_name,
+    ]);
+
+    let output = cmd.output().expect("Failed to get assistant (text format)");
+    assert!(output.status.success(), "Get (text) should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    println!("Text stdout:\n{}", stdout);
+    println!("Text stderr:\n{}", stderr);
+
+    // Description appears in stderr as part of "Assistant Details" section
+    // (CLI uses eprintln! for detailed output)
+    assert!(
+        stderr.contains("Description:") && stderr.contains(updated_description),
+        "Description should appear in text output (stderr)"
+    );
+
+    println!("✓ Description appears in text format output");
+
+    println!("\n==================================================");
+    println!("✓ All CLI description field tests passed!");
+    println!(
+        "  Note: Assistant '{}' created (cleanup needed)",
+        assistant_name
+    );
+    println!("==================================================\n");
+}
+
+#[test]
+#[serial] // Uses shared TEST_DEPLOYMENT - must run serially with other shared deployment tests
 #[ignore] // Blocked by #131 - Delete command has clap flag conflict
 fn test_assistant_lifecycle() {
     println!("==================================================");

--- a/sdk/src/assistants.rs
+++ b/sdk/src/assistants.rs
@@ -77,6 +77,9 @@ pub struct Assistant {
     pub graph_id: String,
     /// Name of the assistant
     pub name: String,
+    /// Description of the assistant
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Configuration for the assistant
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<serde_json::Value>,
@@ -98,6 +101,9 @@ pub struct CreateAssistantRequest {
     pub graph_id: String,
     /// Name for the assistant
     pub name: String,
+    /// Optional description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Optional configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<serde_json::Value>,
@@ -112,6 +118,9 @@ pub struct UpdateAssistantRequest {
     /// Updated name
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Updated description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Updated configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<serde_json::Value>,
@@ -282,6 +291,7 @@ mod tests {
             assistant_id: "test-id".to_string(),
             graph_id: "graph-123".to_string(),
             name: "Test Assistant".to_string(),
+            description: Some("Test description".to_string()),
             config: Some(serde_json::json!({"key": "value"})),
             metadata: None,
             created_at: Some("2024-01-01T00:00:00Z".to_string()),
@@ -298,6 +308,7 @@ mod tests {
         let request = CreateAssistantRequest {
             graph_id: "graph-123".to_string(),
             name: "My Assistant".to_string(),
+            description: Some("My description".to_string()),
             config: Some(serde_json::json!({"temperature": 0.7})),
             metadata: None,
         };

--- a/sdk/tests/assistant_integration_test.rs
+++ b/sdk/tests/assistant_integration_test.rs
@@ -108,6 +108,7 @@ async fn test_assistant_lifecycle() {
     let create_request = CreateAssistantRequest {
         graph_id: graph_name.clone(),
         name: test_name.clone(),
+        description: None,
         config: Some(json!({"configurable": {"test": true}})),
         metadata: Some(json!({"purpose": "integration_test"})),
     };
@@ -155,6 +156,7 @@ async fn test_assistant_lifecycle() {
 
     let update_request = UpdateAssistantRequest {
         name: Some(updated_name.clone()),
+        description: None,
         config: Some(json!({"configurable": {"test": true, "updated": true}})),
         metadata: Some(json!({"purpose": "integration_test", "updated": true})),
     };
@@ -249,6 +251,7 @@ async fn test_assistant_search() {
     let create_request1 = CreateAssistantRequest {
         graph_id: graph_name.clone(),
         name: assistant1_name.clone(),
+        description: None,
         config: None,
         metadata: Some(json!({"test": "search"})),
     };
@@ -262,6 +265,7 @@ async fn test_assistant_search() {
     let create_request2 = CreateAssistantRequest {
         graph_id: graph_name.clone(),
         name: assistant2_name.clone(),
+        description: None,
         config: None,
         metadata: Some(json!({"test": "search"})),
     };
@@ -407,6 +411,7 @@ async fn test_list_assistants() {
     let create_request = CreateAssistantRequest {
         graph_id: graph_name.clone(),
         name: test_name.clone(),
+        description: None,
         config: None,
         metadata: None,
     };
@@ -519,6 +524,7 @@ async fn test_error_handling() {
 
     let update_request = UpdateAssistantRequest {
         name: Some("updated-name".to_string()),
+        description: None,
         config: None,
         metadata: None,
     };

--- a/sdk/tests/assistant_integration_test.rs
+++ b/sdk/tests/assistant_integration_test.rs
@@ -475,6 +475,216 @@ async fn test_list_assistants() {
     println!("==================================================\n");
 }
 
+/// Integration test for assistant description field functionality
+///
+/// This test verifies the description field works correctly:
+/// - Create assistant WITH description
+/// - Verify description is returned in GET
+/// - Update assistant description
+/// - Verify updated description persists
+/// - Test None description handling
+///
+/// **Prerequisites:** Same as test_assistant_lifecycle
+///
+/// Run with: cargo test --test assistant_integration_test test_assistant_description_field -- --ignored --nocapture
+#[tokio::test]
+#[ignore]
+async fn test_assistant_description_field() {
+    println!("==================================================");
+    println!("Test: Assistant Description Field");
+    println!("==================================================\n");
+
+    // Load authentication from environment
+    let auth =
+        AuthConfig::from_env().expect("LANGSMITH_API_KEY and LANGSMITH_WORKSPACE_ID must be set");
+
+    auth.require_langsmith_key()
+        .expect("LANGSMITH_API_KEY is required");
+
+    if auth.workspace_id.is_none() {
+        panic!("LANGSMITH_WORKSPACE_ID is required for assistant tests");
+    }
+
+    // Create client
+    let client = LangchainClient::new(auth).expect("Failed to create client");
+
+    // Discover test deployment and get custom URL
+    let (graph_name, custom_url) = discover_test_deployment(&client).await;
+
+    // Override client with deployment's custom URL
+    let client = client.with_langgraph_url(custom_url);
+
+    println!("\n1. CREATE assistant WITH description");
+    println!("--------------------------------------------------");
+
+    let test_name = generate_test_name("test-assistant-desc");
+    let test_description = "This is a test assistant for verifying description field support";
+    println!("  Creating assistant: {}", test_name);
+    println!("  Description: {}", test_description);
+
+    let create_request = CreateAssistantRequest {
+        graph_id: graph_name.clone(),
+        name: test_name.clone(),
+        description: Some(test_description.to_string()),
+        config: Some(json!({"configurable": {"test": true}})),
+        metadata: Some(json!({"purpose": "description_test"})),
+    };
+
+    let created_assistant = client
+        .assistants()
+        .create(&create_request)
+        .await
+        .expect("Failed to create assistant");
+
+    println!("✓ Assistant created successfully");
+    println!("  Assistant ID: {}", created_assistant.assistant_id);
+    println!("  Name: {}", created_assistant.name);
+    println!("  Description: {:?}", created_assistant.description);
+
+    assert_eq!(created_assistant.name, test_name);
+    assert_eq!(created_assistant.graph_id, graph_name);
+    assert!(
+        created_assistant.description.is_some(),
+        "Description should be Some"
+    );
+    assert_eq!(
+        created_assistant.description.as_ref().unwrap(),
+        test_description,
+        "Description should match the one we set"
+    );
+
+    let assistant_id = created_assistant.assistant_id.clone();
+
+    println!("\n2. GET assistant and verify description");
+    println!("--------------------------------------------------");
+    println!("  Fetching assistant: {}", assistant_id);
+
+    let fetched_assistant = client
+        .assistants()
+        .get(&assistant_id)
+        .await
+        .expect("Failed to get assistant");
+
+    println!("✓ Assistant fetched successfully");
+    println!("  Name: {}", fetched_assistant.name);
+    println!("  Description: {:?}", fetched_assistant.description);
+
+    assert_eq!(fetched_assistant.assistant_id, assistant_id);
+    assert_eq!(fetched_assistant.name, test_name);
+    assert!(
+        fetched_assistant.description.is_some(),
+        "Fetched assistant should have description"
+    );
+    assert_eq!(
+        fetched_assistant.description.as_ref().unwrap(),
+        test_description,
+        "Fetched description should match original"
+    );
+
+    println!("\n3. UPDATE assistant description");
+    println!("--------------------------------------------------");
+
+    let updated_description = "Updated description - testing description update functionality";
+    println!("  Updating description to: {}", updated_description);
+
+    let update_request = UpdateAssistantRequest {
+        name: None, // Don't change the name
+        description: Some(updated_description.to_string()),
+        config: None,
+        metadata: None,
+    };
+
+    let updated_assistant = client
+        .assistants()
+        .update(&assistant_id, &update_request)
+        .await
+        .expect("Failed to update assistant");
+
+    println!("✓ Assistant updated successfully");
+    println!("  Description: {:?}", updated_assistant.description);
+
+    assert_eq!(updated_assistant.assistant_id, assistant_id);
+    assert_eq!(updated_assistant.name, test_name, "Name should not change");
+    assert!(
+        updated_assistant.description.is_some(),
+        "Updated description should be Some"
+    );
+    assert_eq!(
+        updated_assistant.description.as_ref().unwrap(),
+        updated_description,
+        "Description should be updated"
+    );
+
+    // Verify update persisted
+    println!("  Verifying updated description persisted...");
+    let refetched_assistant = client
+        .assistants()
+        .get(&assistant_id)
+        .await
+        .expect("Failed to refetch assistant");
+
+    assert_eq!(
+        refetched_assistant.description.as_ref().unwrap(),
+        updated_description,
+        "Updated description should persist"
+    );
+    println!("✓ Updated description persisted correctly");
+
+    println!("\n4. UPDATE to clear description (set to None)");
+    println!("--------------------------------------------------");
+
+    let clear_request = UpdateAssistantRequest {
+        name: None,
+        description: None, // Clear the description
+        config: None,
+        metadata: None,
+    };
+
+    let cleared_assistant = client
+        .assistants()
+        .update(&assistant_id, &clear_request)
+        .await
+        .expect("Failed to clear description");
+
+    println!("✓ Description cleared");
+    println!("  Description: {:?}", cleared_assistant.description);
+
+    // Note: The API behavior for None may vary:
+    // - Some APIs treat None as "no change" (keep existing value)
+    // - Some APIs treat None as "clear the field" (set to null)
+    // This test documents the actual behavior
+    println!(
+        "  Actual behavior: description = {:?}",
+        cleared_assistant.description
+    );
+
+    println!("\n5. DELETE assistant");
+    println!("--------------------------------------------------");
+    println!("  Deleting assistant: {}", assistant_id);
+
+    client
+        .assistants()
+        .delete(&assistant_id)
+        .await
+        .expect("Failed to delete assistant");
+
+    println!("✓ Assistant deleted successfully");
+
+    // Verify deletion - get should fail
+    println!("  Verifying deletion...");
+    let get_result = client.assistants().get(&assistant_id).await;
+
+    assert!(
+        get_result.is_err(),
+        "Get should fail after deletion, but succeeded"
+    );
+    println!("✓ Confirmed assistant no longer exists");
+
+    println!("\n==================================================");
+    println!("✓ All description field tests passed!");
+    println!("==================================================\n");
+}
+
 /// Integration test for error handling
 ///
 /// **Prerequisites:** Same as test_assistant_lifecycle


### PR DESCRIPTION
## Summary

Implements support for the `description` field from the LangSmith Agent Server API in both SDK and CLI.

## Changes

### SDK (`sdk/src/assistants.rs`)
- Add `description: Option<String>` to `Assistant` struct
- Add `description: Option<String>` to `CreateAssistantRequest` struct  
- Add `description: Option<String>` to `UpdateAssistantRequest` struct
- Update unit tests to include description field
- Update integration tests to include description field

### CLI (`cli/src/commands/assistant.rs`)
- Add `--description` flag to `assistant create` command
- Add `--description` flag to `assistant update` command
- Add "description" to available columns for text output
- Display description in `assistant get` command output
- Update `ColumnMetadata::render_tsv` to handle description column

## API Specification

According to the [Agent Server API docs](https://docs.langchain.com/langsmith/agent-server-api/assistants/get-assistant):
- **Type:** `string | null`
- **Required:** No (optional field)
- **Description:** "The description of the assistant"

## Test Plan

- [x] Code compiles (cargo check)
- [x] Clippy passes (cargo clippy)
- [x] Unit tests updated and pass
- [x] Integration tests updated (existing tests modified to include description field)
- [x] Integration tests for description CRUD operations (to be added in follow-up)

## Related Issues

Fixes #725

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)