### PR TITLE
📚 docs: add background task management guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,25 @@ When working on complex tasks:
   1. Proceed with a summarized version within the limit
   2. Break the task into multiple smaller requests
   3. Temporarily increase the limit for this specific task
+
+## Background Task Management
+
+**CRITICAL: Never use `tail -f` to monitor background tasks** - it runs indefinitely and leaves processes running.
+
+**Correct approach for monitoring background tasks:**
+
+```bash
+# ❌ WRONG - leaves tail -f running forever
+cargo nextest run --workspace &
+tail -f /tmp/output.log
+
+# ✅ CORRECT - use TaskOutput with block=true
+cargo nextest run --workspace  # This runs in background automatically
+# Then use TaskOutput tool with block=true to wait for completion
+```
+
+**Rules:**
+- Use `TaskOutput` tool with `block=true` to wait for background command completion
+- NEVER use `tail -f` - it runs until manually killed
+- If you accidentally start `tail -f`, immediately use `KillShell` to stop it
+- Background tasks from Bash tool are automatically monitored - don't add extra monitoring

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ cargo nextest run --workspace &
 tail -f /tmp/output.log
 
 # ✅ CORRECT - use TaskOutput with block=true
-cargo nextest run --workspace  # This runs in background automatically
+cargo nextest run --workspace # This runs in background automatically
 # Then use TaskOutput tool with block=true to wait for completion
 ```
 


### PR DESCRIPTION
## Summary

Adds critical guidelines about background task management to CLAUDE.md, specifically warning against using `tail -f` to monitor background tasks.

## Problem

`tail -f` was used twice to monitor background task output, leaving processes running indefinitely that required manual cleanup with KillShell.

## Solution

Added new section to CLAUDE.md with:
- Clear warning: NEVER use `tail -f` to monitor background tasks
- Correct approach: Use TaskOutput tool with block=true
- Rules for cleanup if `tail -f` is accidentally started

## Changes

- Added "Background Task Management" section after "Output Token Budget"
- Documented correct vs incorrect patterns with examples
- Added rules for handling background tasks properly

## Related Issues

Fixes #731

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior. Main risk is minor: guidance could be misapplied if the described tooling behavior differs from reality.
> 
> **Overview**
> Adds a new **Background Task Management** section to `CLAUDE.md` that explicitly forbids using `tail -f` to monitor background jobs.
> 
> Documents the preferred pattern for waiting on background work via `TaskOutput` with `block=true`, and adds cleanup rules (use `KillShell` if `tail -f` is started) to avoid leaving long-running processes behind.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f213634794ceda0afc2792579bddd440a5ab2554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->